### PR TITLE
GitHub Webhooks

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -208,9 +208,9 @@ function batchSetLibrariesForRelease(batch, libraries, releaseId) {
  * object, and deletes any existing library versions associated with the
  * release.
  *
- * @param {Object} libraries Object mapping library names to their
- * versions, optedIn and isLockstep flags.
- * @param {string} releaseId The ID of the associated release.
+ * @param {admin.firestore.WriteBatch} libraries The batch to add the
+ * delete operations to.
+ * @param {string} releaseId
  */
 async function updateLibrariesForRelease(libraries, releaseId) {
   const batch = db.batch();

--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -1,6 +1,5 @@
 const admin = require("firebase-admin");
 const db = admin.firestore();
-const {Timestamp} = require("firebase-admin/firestore");
 const RELEASE_STATES = require("../utils/releaseStates.js");
 const {
   validateNewReleasesStructure,

--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -351,7 +351,6 @@ async function updateChangesForRelease(releaseReport, releaseId) {
   await batch.commit();
 }
 
-
 /**
  * Deletes all existing check documents associated with a release.
  *
@@ -414,6 +413,30 @@ async function updateChecksForRelease(checkRunList, releaseId) {
   await batch.commit();
 }
 
+/**
+  * Update a check run in Firestore.
+  *
+  * This function is not to be used for creating new check runs.
+  * Because of this, it does not set fields that are static.
+  *
+  * @param {string} checkRunId The ID of the check run to update.
+  * @param {string} headSHA The SHA of the commit that the check run
+  * is associated with.
+  * @param {string} status The status of the check run.
+  * @param {string} conclusion The conclusion of the check run.
+  * @throws {Error} If the check run does not exist in Firestore.
+  * @return {Promise<void>} A promise that resolves when the check run
+  * has been updated.
+  */
+async function updateCheckRunStatus(checkRunId, headSHA, status, conclusion) {
+  const docRef = db.collection("checks").doc(checkRunId);
+  await docRef.set({
+    headSHA: headSHA,
+    status: status,
+    conclusion: conclusion,
+  });
+}
+
 module.exports = {
   setReleases,
   getReleaseID,
@@ -424,4 +447,5 @@ module.exports = {
   updateChangesForRelease,
   updateChecksForRelease,
   getReleaseData,
+  updateCheckRunStatus,
 };

--- a/functions/github/github.js
+++ b/functions/github/github.js
@@ -271,6 +271,17 @@ async function getBuildArtifactsWorkflow(octokit, releaseBranchName) {
 /**
   * Verifies the signature of a request.
   *
+  * We want to limit requests to those coming from GitHub. To do this, we
+  * verify the signature of the request using the secret set in the webhook.
+  * The signature is passed in the `x-hub-signature` header as a SHA256 HMAC
+  * hex digest. The signature is generated using the request body as the
+  * message and the secret as the key. The signature in the header is prefixed
+  * with `sha256=`. We verify the signature by generating our own signature
+  * using the secret and the request body and comparing it to the signature
+  * in the header. If they match, the request is verified.
+  *
+  * See https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks
+  *
   * @param {Object} req The request to verify.
   * @param {string} secret The secret to use to verify the signature.
   * @return {boolean} True if the signature is valid, false otherwise.

--- a/functions/github/github.js
+++ b/functions/github/github.js
@@ -1,5 +1,6 @@
 const {log, error} = require("firebase-functions/logger");
 const {parseGradlePropertiesForVersion} = require("../utils/utils.js");
+const crypto = require("crypto");
 
 const OWNER = "firebase";
 const REPO = "firebase-android-sdk";
@@ -267,6 +268,22 @@ async function getBuildArtifactsWorkflow(octokit, releaseBranchName) {
   }
 }
 
+/**
+  * Verifies the signature of a request.
+  *
+  * @param {Object} req The request to verify.
+  * @param {string} secret The secret to use to verify the signature.
+  * @return {boolean} True if the signature is valid, false otherwise.
+  */
+function verifySignature(req, secret) {
+  const signature = crypto
+      .createHmac("sha256", secret)
+      .update(JSON.stringify(req.body))
+      .digest("hex");
+
+  return `sha256=${signature}` === req.headers["x-hub-signature-256"];
+}
+
 module.exports = {
   listCheckRuns,
   getReleaseConfig,
@@ -274,5 +291,6 @@ module.exports = {
   getLibraryMetadata,
   checkReleaseBranchExists,
   getBuildArtifactsWorkflow,
+  verifySignature,
   REPO_URL,
 };

--- a/functions/github/webhooks.js
+++ b/functions/github/webhooks.js
@@ -1,0 +1,120 @@
+const {
+  getReleaseIdFromBranch,
+} = require("../database/database.js");
+const {
+  syncReleaseState,
+} = require("../handlers/handlers.js");
+const {
+  verifySignature,
+} = require("./github.js");
+const {Octokit} = require("@octokit/rest");
+const {error, log} = require("firebase-functions/logger");
+const {defineSecret} = require("firebase-functions/params");
+const GITHUB_WEBHOOK_SECRET = defineSecret("GITHUB_WEBHOOK_SECRET");
+const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
+
+/**
+  * Handles a GitHub check run event. This function is called when a check run
+  * is created, completed, or rerequested. It updates the release state if
+  * necessary.
+  *
+  * @param {Object} req - The request object.
+  * @param {Object} res - The response object.
+  * @return {Promise} A promise that resolves when the request is complete.
+  */
+async function githubWebhook(req, res) {
+  if (!verifySignature(req, GITHUB_WEBHOOK_SECRET.value())) {
+    return res.status(401).send("Unauthorized");
+  }
+
+  const payload = req.body;
+  const eventType = req.headers["x-github-event"];
+
+  log("Received GitHub webhook", {payload: payload, eventType: eventType});
+
+  try {
+    if (eventType === "check_run") {
+      // TODO
+      // await handleCheckRunEvent(payload);
+    } else if (eventType === "push") {
+      // TODO
+      // await handlePushEvent(payload);
+    } else if (eventType === "pull_request") {
+      await handlePullRequestEvent(payload);
+    }
+  } catch (err) {
+    error("Failed to handle GitHub webhook",
+        {
+          error: err.message,
+          payload: payload,
+          eventType: eventType,
+        },
+    );
+    return res.status(500).send("Internal Server Error");
+  }
+
+  return res.status(200).send("OK");
+}
+
+/**
+  * Handles a GitHub pull request event.
+  *
+  * This function is called when a pull
+  * request is opened. It updates the release state if the pull request
+  * was opened on a branch that is currently being tracked by one of the
+  * releases.
+  *
+  * @param {Object} payload The payload from the GitHub webhook.
+  * @return {Promise<void>}
+  */
+async function handlePullRequestEvent(payload) {
+  if (payload.action === "opened") {
+    const pullRequest = payload.pull_request;
+
+    if (pullRequest && pullRequest.head) {
+      const branchName = pullRequest.head.ref;
+      log("Pull request event", {branchName: branchName});
+
+      let releaseId;
+      try {
+        releaseId = await getReleaseIdFromBranch(branchName);
+      } catch (err) {
+        error("Error getting release ID from branch name",
+            {error: err.message});
+        return;
+      }
+
+      // If the releaseId exists, then a pull request was opened on a branch
+      // that is being tracked for a release.
+      //
+      // We assume that once a pull request is created on a release branch,
+      // the release configuration has been successfully generated.
+      // If this assumption is wrong, then the release will enter an error
+      // state.
+      if (releaseId) {
+        try {
+          log("Pull request opened on a release branch",
+              {
+                releaseId: releaseId,
+                branchName: branchName,
+                pullRequest: pullRequest,
+              });
+          const octokit = new Octokit({auth: GITHUB_TOKEN.value()});
+          await syncReleaseState(releaseId, octokit);
+          log("Successfully synced release state", {releaseId: releaseId});
+        } catch (err) {
+          error("Failed to sync release state", {error: err.message});
+        }
+      } else {
+        log("Pull request opened on a non-release branch",
+            {branchName: branchName});
+      }
+    }
+  }
+}
+
+
+module.exports = {
+  githubWebhook,
+  handlePullRequestEvent,
+};

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -2,7 +2,6 @@ const admin = require("firebase-admin");
 const {Octokit} = require("@octokit/rest");
 const {defineSecret} = require("firebase-functions/params");
 const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
-const GITHUB_WEBHOOK_SECRET = defineSecret("GITHUB_WEBHOOK_SECRET");
 
 const {
   log,
@@ -26,7 +25,6 @@ const {
   getBuildArtifactsWorkflow,
   listCheckRuns,
   getLibraryMetadata,
-  verifySignature,
 } = require("../github/github.js");
 const {validateNewReleases} = require("../validation/validation.js");
 const {
@@ -560,32 +558,11 @@ async function syncReleaseState(releaseId, octokit) {
   }
 }
 
-/**
-  * Handles a GitHub check run event. This function is called when a check run
-  * is created, completed, or rerequested. It updates the release state if
-  * necessary.
-  *
-  * @param {Object} req - The request object.
-  * @param {Object} res - The response object.
-  * @return {Promise} A promise that resolves when the request is complete.
-  */
-async function githubWebhook(req, res) {
-  if (!verifySignature(req, GITHUB_WEBHOOK_SECRET.value())) {
-    return res.status(401).send("Unauthorized");
-  }
-
-  const payload = req.body;
-  const eventType = req.headers["x-github-event"];
-
-  log("Received GitHub webhook", {eventType: eventType, payload: payload});
-
-  return res.status(200).send("OK");
-}
 
 module.exports = {
   addReleases,
   refreshRelease,
   getReleases,
   modifyReleases,
-  githubWebhook,
+  syncReleaseState,
 };

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -2,6 +2,7 @@ const admin = require("firebase-admin");
 const {Octokit} = require("@octokit/rest");
 const {defineSecret} = require("firebase-functions/params");
 const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
+const GITHUB_WEBHOOK_SECRET = defineSecret("GITHUB_WEBHOOK_SECRET");
 
 const {
   log,
@@ -25,6 +26,7 @@ const {
   getBuildArtifactsWorkflow,
   listCheckRuns,
   getLibraryMetadata,
+  verifySignature,
 } = require("../github/github.js");
 const {validateNewReleases} = require("../validation/validation.js");
 const {
@@ -558,9 +560,32 @@ async function syncReleaseState(releaseId, octokit) {
   }
 }
 
+/**
+  * Handles a GitHub check run event. This function is called when a check run
+  * is created, completed, or rerequested. It updates the release state if
+  * necessary.
+  *
+  * @param {Object} req - The request object.
+  * @param {Object} res - The response object.
+  * @return {Promise} A promise that resolves when the request is complete.
+  */
+async function githubWebhook(req, res) {
+  if (!verifySignature(req, GITHUB_WEBHOOK_SECRET.value())) {
+    return res.status(401).send("Unauthorized");
+  }
+
+  const payload = req.body;
+  const eventType = req.headers["x-github-event"];
+
+  log("Received GitHub webhook", {eventType: eventType, payload: payload});
+
+  return res.status(200).send("OK");
+}
+
 module.exports = {
   addReleases,
   refreshRelease,
   getReleases,
   modifyReleases,
+  githubWebhook,
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,8 +9,10 @@ const {
   refreshRelease,
   getReleases,
   modifyReleases,
-  githubWebhook,
 } = require("./handlers/handlers.js");
+const {
+  githubWebhook,
+} = require("./github/webhooks.js");
 const {defineSecret} = require("firebase-functions/params");
 const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
 const GITHUB_WEBHOOK_SECRET = defineSecret("GITHUB_WEBHOOK_SECRET");

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,9 +9,11 @@ const {
   refreshRelease,
   getReleases,
   modifyReleases,
+  githubWebhook,
 } = require("./handlers/handlers.js");
 const {defineSecret} = require("firebase-functions/params");
 const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
+const GITHUB_WEBHOOK_SECRET = defineSecret("GITHUB_WEBHOOK_SECRET");
 
 exports.addReleases = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
@@ -23,3 +25,6 @@ exports.modifyReleases = functions.https.onRequest(
 exports.refreshRelease = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
     refreshRelease);
+exports.githubWebhook = functions.https.onRequest(
+    {secrets: [GITHUB_TOKEN, GITHUB_WEBHOOK_SECRET]},
+    githubWebhook);

--- a/functions/test/utils/utils.test.js
+++ b/functions/test/utils/utils.test.js
@@ -68,13 +68,11 @@ describe("convertReleaseDatesToTimestamps", () => {
   });
 });
 
-
 describe("calculateReleaseState", () => {
   it("should return SCHEDULED if code freeze is more than 2 days away", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
     const release = new Date(codeFreeze.getTime() + 5 * 24 * 60 * 60 * 1000);
-
     expect(calculateReleaseState(codeFreeze, release, false))
         .to.equal(RELEASE_STATES.SCHEDULED);
   });
@@ -83,14 +81,12 @@ describe("calculateReleaseState", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() + 24 * 60 * 60 * 1000);
     const release = new Date(codeFreeze.getTime() + 2 * 24 * 60 * 60 * 1000);
-
     expect(calculateReleaseState(codeFreeze, release, false))
         .to.equal(RELEASE_STATES.UPCOMING);
   });
 
   it("should throw error if unable to calculate state", () => {
     const now = new Date();
-
     expect(() => calculateReleaseState(now, now, false))
         .to.throw("Unable to calculate release state");
   });
@@ -100,7 +96,6 @@ describe("calculateReleaseState", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     const release = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-
     expect(calculateReleaseState(codeFreeze, release, false))
         .to.equal(RELEASE_STATES.CODE_FREEZE);
   });
@@ -109,7 +104,6 @@ describe("calculateReleaseState", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
     const release = new Date(now.setHours(0, 0, 0, 0));
-
     expect(calculateReleaseState(codeFreeze, release, false))
         .to.equal(RELEASE_STATES.RELEASE_DAY);
   });
@@ -119,7 +113,6 @@ describe("calculateReleaseState", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000);
     const release = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
-
     expect(calculateReleaseState(codeFreeze, release, true))
         .to.equal(RELEASE_STATES.RELEASED);
   });
@@ -129,7 +122,6 @@ describe("calculateReleaseState", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000);
     const release = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
-
     expect(calculateReleaseState(codeFreeze, release, false))
         .to.equal(RELEASE_STATES.DELAYED);
   });
@@ -178,40 +170,34 @@ describe("parseGradlePropertiesForVersion", () => {
   it("should work on the simple case", () => {
     const gradleProps = "version=1.2.3";
     const version = parseGradlePropertiesForVersion(gradleProps);
-
     expect(version).to.equal("1.2.3");
   });
   it("should ignore commented lines", () => {
     const gradleProps = `#version=1.2.3\nversion=2.3.4`;
     const version = parseGradlePropertiesForVersion(gradleProps);
-
     expect(version).to.equal("2.3.4");
   });
 
   it("should handle leading and trailing whitespace", () => {
     const gradleProps = " \t version = 3.4.5 \t ";
     const version = parseGradlePropertiesForVersion(gradleProps);
-
     expect(version).to.equal("3.4.5");
   });
 
   it("should handle case-insensitivity", () => {
     const gradleProps = "VERSION=4.5.6";
     const version = parseGradlePropertiesForVersion(gradleProps);
-
     expect(version).to.equal("4.5.6");
   });
 
   it("should ignore lines without equals sign", () => {
     const gradleProps = "version\nversion=5.6.7";
     const version = parseGradlePropertiesForVersion(gradleProps);
-
     expect(version).to.equal("5.6.7");
   });
 
   it("should throw an error when no version is found", () => {
     const gradleProps = "no version here";
-
     expect(() => parseGradlePropertiesForVersion(gradleProps)).to.throw();
   });
 });
@@ -223,7 +209,6 @@ describe("parseCommitTitleFromMessage", () => {
       
       * Making methods in core.Query that memoize results thread safe.`;
     const result = parseCommitTitleFromMessage(message);
-
     expect(result).to
         .equal(
             "Making methods in core.Query that memoize "+
@@ -233,13 +218,11 @@ describe("parseCommitTitleFromMessage", () => {
 
   it("should throw an error if the pattern is not found", () => {
     const message = "No pattern match in this string.";
-
     expect(() => parseCommitTitleFromMessage(message)).to.throw();
   });
 
   it("should throw an error on empty strings", () => {
     const message = "";
-
     expect(() => parseCommitTitleFromMessage(message)).to.throw();
   });
 });

--- a/functions/test/utils/utils.test.js
+++ b/functions/test/utils/utils.test.js
@@ -15,14 +15,12 @@ describe("convertDateToTimestamp", () => {
   it("should correctly convert a date string to a Firestore Timestamp", () => {
     const dateString = "2023-07-19";
     const result = convertDateToTimestamp(dateString);
-
     expect(result).to.be.an.instanceof(Timestamp);
   });
 
   it("should throw an error if date string format is invalid", () => {
     const dateString = "invalid-date-format";
     const consoleErrorStub = sinon.stub(console, "error");
-
     expect(() => convertDateToTimestamp(dateString)).to.throw();
     consoleErrorStub.restore();
   });
@@ -67,6 +65,7 @@ describe("convertReleaseDatesToTimestamps", () => {
     expect(result[0]).to.deep.equal(mockReleases[0]);
   });
 });
+
 
 describe("calculateReleaseState", () => {
   it("should return SCHEDULED if code freeze is more than 2 days away", () => {


### PR DESCRIPTION
- Added API endpoint to receive GitHub webhooks.
- Authenticating webhooks [Securing your webhooks](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks)
- Triggering a sync with GitHub data when a PR on a branch that is being tracked by a release is created or updated
- Updating the status of check runs on release branches when check runs are queued or completed

Note: This PR does not include updates to the build release artifacts job. Testing this is challenging without webhooks set up in the Android SDK repo.

Set base branch to firebase-functions to avoid noisy diff.
