### PR TITLE
Modified API endpoints to accept release IDs instead of release names

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -10,6 +10,21 @@ const {REPO_URL} = require("../github/github.js");
 const {warn} = require("firebase-functions/logger");
 
 /**
+ * Check if a release document with a given releaseId exists in Firestore.
+ *
+ * @param {string} releaseId - The ID of the release to check
+ * @return {Promise<boolean>} - A promise that resolves to true if the
+ * release exists, false otherwise.
+ */
+async function releaseExists(releaseId) {
+  const releaseSnapshot = await db.collection("releases")
+      .doc(releaseId)
+      .get();
+
+  return releaseSnapshot.exists;
+}
+
+/**
  * Retrieve the release ID of the Firestore release document
  * with a given release name.
  *
@@ -460,6 +475,7 @@ async function deleteAllReleaseData(releaseId) {
 }
 
 module.exports = {
+  releaseExists,
   setReleases,
   getReleaseID,
   getReleaseIdFromBranch,

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,7 +8,6 @@ const {
   addReleases,
   refreshRelease,
   getReleases,
-  modifyReleases,
   modifyRelease,
   deleteRelease,
 } = require("./handlers/handlers.js");
@@ -23,9 +22,6 @@ exports.addReleases = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
     addReleases);
 exports.getReleases = functions.https.onRequest(getReleases);
-exports.modifyReleases = functions.https.onRequest(
-    {secrets: [GITHUB_TOKEN]},
-    modifyReleases);
 exports.modifyRelease = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
     modifyRelease);

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,7 @@ const {
   refreshRelease,
   getReleases,
   modifyReleases,
+  modifyRelease,
   deleteRelease,
 } = require("./handlers/handlers.js");
 const {
@@ -25,6 +26,9 @@ exports.getReleases = functions.https.onRequest(getReleases);
 exports.modifyReleases = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
     modifyReleases);
+exports.modifyRelease = functions.https.onRequest(
+    {secrets: [GITHUB_TOKEN]},
+    modifyRelease);
 exports.refreshRelease = functions.https.onRequest(
     {secrets: [GITHUB_TOKEN]},
     refreshRelease);


### PR DESCRIPTION
While release names are unique, they raise issues when attempting to
modify releases. If we want to modify the name of a release (its
primary key) we need to pass both the previous release name and the new
release name. A cleaner, more correct approach is to just give clients
the Ids of the releases, and accept those instead. This also removes the
need to look up the release with the given release name.

I should have done this from the start!

I also removed the `modifyReleases` endpoint in favor of a simpler `modifyRelease` endpoint. Batch edits are not noticeably faster and are an uncommon use case. The frontend will likely just support submitting modifications for a single release at a time.