### PR TITLE
Removed release operator from Firestore writes

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -109,7 +109,7 @@ function releaseToFirestoreObject(release) {
   return {
     state: RELEASE_STATES.SCHEDULED,
     releaseName: release.releaseName,
-    releaseOperator: release.releaseOperator,
+    releaseOperator: "ACore Team Member", // release.releaseOperator,
     codeFreezeDate: release.codeFreezeDate,
     releaseDate: release.releaseDate,
     snapshotBranchName: snapshotBranchName,


### PR DESCRIPTION
Removed the release operator from Firestore writes.

They are still required to be sent by clients, they just won't be stored in Firestore. This is just so that it's easy to revert this change from both the client and server-side once we can store the release operators.
