### PR TITLE
Fix library updates

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -244,7 +244,8 @@ async function batchDeleteReleaseLibraries(batch, releaseId) {
 function batchSetLibrariesForRelease(batch, libraries, releaseId) {
   Object.entries(libraries).forEach(
       ([libraryName, {updatedVersion, optedIn, libraryGroupRelease}]) => {
-        const docRef = db.collection("libraries").doc();
+        const uniqueId = `${libraryName}-${updatedVersion}`;
+        const docRef = db.collection("libraries").doc(uniqueId);
         batch.set(docRef, {
           libraryName,
           updatedVersion,


### PR DESCRIPTION
Libraries weren't being updated because we were creating new ones, instead of updating a document with a specific ID. To make this easier, we can instead use the library name and the version to make a primary key that is easy to reference for updates.