### PR TITLE
Set release branch for new releases

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -119,21 +119,14 @@ async function getReleaseData(releaseId) {
  * @return {Object} - A release data object ready for storage
  */
 function releaseToFirestoreObject(release) {
-  const snapshotBranchName = `releases/${release.releaseName}`;
-  const releaseBranchName = `releases/${release.releaseName}.release`;
-  const snapshotBranchLink = `${REPO_URL}/tree/${snapshotBranchName}`;
-  const releaseBranchLink = `${REPO_URL}/tree/${releaseBranchName}`;
-
   return {
     state: RELEASE_STATES.SCHEDULED,
     releaseName: release.releaseName,
     releaseOperator: "ACore Team Member", // release.releaseOperator,
     codeFreezeDate: release.codeFreezeDate,
     releaseDate: release.releaseDate,
-    snapshotBranchName: snapshotBranchName,
-    snapshotBranchLink: snapshotBranchLink,
-    releaseBranchName: releaseBranchName,
-    releaseBranchLink: releaseBranchLink,
+    releaseBranchName: release.releaseBranchName,
+    releaseBranchLink: `${REPO_URL}/tree/${release.releaseBranchName}`,
     isComplete: false,
     buildArtifactStatus: "",
     buildArtifactConclusion: "",

--- a/functions/test/validation/validation.test.js
+++ b/functions/test/validation/validation.test.js
@@ -53,18 +53,21 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
       {
         releaseName: "M104",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-08-07",
+        releaseBranchName: "branch",
       },
       {
         releaseName: "M105",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-08-30",
         releaseDate: "2123-09-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -80,18 +83,21 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
       {
         releaseName: "M104",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-08-07",
+        releaseBranchName: "branch",
       },
       {
         releaseName: "M105",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-08-30",
         releaseDate: "2123-09-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [
@@ -100,6 +106,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2022-06-30",
         releaseDate: "2022-07-07",
+        releaseBranchName: "branch",
       },
     ];
     const errors = await validateNewReleases(newReleases, existingReleases);
@@ -113,6 +120,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -133,6 +141,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -153,6 +162,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "not a date",
         releaseDate: "not a date",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -174,6 +184,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -195,6 +206,7 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-07",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
     ];
     const existingReleases = [];
@@ -215,7 +227,25 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
       },
+      {
+        releaseName: "M103",
+        releaseOperator: "operator1",
+        codeFreezeDate: "2123-06-30",
+        releaseDate: "2123-07-07",
+        releaseBranchName: "branch",
+      },
+    ];
+    const errors = validateNewReleases(newReleases);
+    const expectedErrors = {
+      message: ERRORS.DUPLICATE_RELEASE_NAMES,
+    };
+    expect(errors).to.deep.include(expectedErrors);
+  });
+
+  it("should return an error for missing a release branch", async () => {
+    const newReleases = [
       {
         releaseName: "M103",
         releaseOperator: "operator1",
@@ -225,7 +255,8 @@ describe("validateNewReleases", () => {
     ];
     const errors = validateNewReleases(newReleases);
     const expectedErrors = {
-      message: ERRORS.DUPLICATE_RELEASE_NAMES,
+      message: ERRORS.MISSING_RELEASE_FIELD,
+      offendingRelease: newReleases[0],
     };
     expect(errors).to.deep.include(expectedErrors);
   });
@@ -270,10 +301,24 @@ describe("validateNewReleasesStructure", () => {
       releaseOperator: "operator1",
       codeFreezeDate: Timestamp.now(),
       // missing release date
+      // missing releaseBranchName
     }];
     expect(() => validateNewReleasesStructure(newReleases)).
         to.throw("Each release should have a Firestore Timestamp"+
           " property 'releaseDate'");
+  });
+
+  it("should throw an error if a release is missing a release branch", () => {
+    const newReleases = [{
+      releaseName: "M100",
+      releaseOperator: "operator1",
+      codeFreezeDate: Timestamp.now(),
+      releaseDate: Timestamp.now(),
+      // missing release branch
+    }];
+    expect(() => validateNewReleasesStructure(newReleases)).
+        to.throw("Each release should have a string property"+
+        " property 'releaseBranchName'");
   });
 
   it("should throw an error if a release property is of incorrect type", () => {
@@ -282,6 +327,7 @@ describe("validateNewReleasesStructure", () => {
       releaseOperator: "operator1",
       codeFreezeDate: Timestamp.now(),
       releaseDate: "not a timestamp",
+      releaseBranchName: "branch",
     }];
     expect(() => validateNewReleasesStructure(newReleases)).
         to.throw("Each release should have a Firestore Timestamp"+
@@ -294,6 +340,7 @@ describe("validateNewReleasesStructure", () => {
       releaseOperator: "operator1",
       codeFreezeDate: Timestamp.now(),
       releaseDate: Timestamp.now(),
+      releaseBranchName: "branch",
     }];
     expect(() => validateNewReleasesStructure(newReleases)).to.not.throw();
   });

--- a/functions/test/validation/validation.test.js
+++ b/functions/test/validation/validation.test.js
@@ -53,10 +53,10 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
-        releaseBranchName: "branch",
+        releaseBranchName: "releases/${releaseName}",
       },
       {
-        releaseName: "M104",
+        releaseName: "m104",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-08-07",
@@ -258,6 +258,7 @@ describe("validateNewReleases", () => {
       message: ERRORS.MISSING_RELEASE_FIELD,
       offendingRelease: newReleases[0],
     };
+
     expect(errors).to.deep.include(expectedErrors);
   });
 });

--- a/functions/validation/validation.js
+++ b/functions/validation/validation.js
@@ -141,6 +141,32 @@ function validateUniqueReleaseNames(releases) {
 }
 
 /**
+ * Validates that the release branch exists.
+ *
+ * @param {Object} release - The release to validate.
+ * @return {Array} errors - A list of errors from the validation of the release
+ * branch.
+ */
+function validateReleaseBranch(release) {
+  const errors = [];
+
+  if (!release.releaseBranchName) {
+    errors.push({
+      message: ERRORS.MISSING_RELEASE_FIELD,
+      offendingRelease: release,
+    });
+  } else if (typeof release.releaseBranchName !== "string" ||
+          release.releaseOperator.trim() === "") {
+    errors.push({
+      message: ERRORS.INVALID_RELEASE_FIELD,
+      offendingRelease: release,
+    });
+  }
+
+  return errors;
+}
+
+/**
  * Validates that a release object is in a valid form.
  *
  * @param {Object} release - The release to validate.
@@ -150,8 +176,14 @@ function validateRelease(release) {
   const releaseNameErrors = validateReleaseName(release);
   const operatorErrors = validateReleaseOperator(release);
   const dateErrors = validateReleaseDates(release);
+  const branchErrors = validateReleaseBranch(release);
 
-  return [...releaseNameErrors, ...operatorErrors, ...dateErrors];
+  return [
+    ...releaseNameErrors,
+    ...operatorErrors,
+    ...dateErrors,
+    ...branchErrors,
+  ];
 }
 
 /**
@@ -218,6 +250,12 @@ function validateNewReleaseStructure(release) {
       !(release.releaseDate instanceof Timestamp)) {
     throw new Error("Each release should have a Firestore Timestamp"+
         " property 'releaseDate'");
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(release, "releaseBranchName") ||
+  !(release.releaseBranchName !== "string")) {
+    throw new Error("Each release should have a string property"+
+    " property 'releaseBranchName'");
   }
 }
 


### PR DESCRIPTION
We used to just automatically set the release branch to be `releases/<releasename>.release`, but now we accept the release branch from the payload.