### PR TITLE
Admin Page with Scheduling, Editing, Deletion, Refreshes

### DIFF
--- a/firebase-android-release-dashboard/package.json
+++ b/firebase-android-release-dashboard/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@material-ui/core": "^4.12.4",

--- a/firebase-android-release-dashboard/src/App.js
+++ b/firebase-android-release-dashboard/src/App.js
@@ -1,13 +1,16 @@
 import React, {useEffect} from "react";
+import {Route, BrowserRouter as Router, Routes} from "react-router-dom";
+
 import {Box, CssBaseline, ThemeProvider} from "@material-ui/core";
 
 import AppErrorBoundary from "./components/Error/AppErrorBoundary";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import MainContent from "./components/MainContent";
+import AdminMain from "./components/AdminPage/AdminMain";
 import theme from "./config/theme";
-import {loadGoogleFont} from "./services/fontLoader";
 import {useAuthentication} from "./hooks/useAuthentication";
+import {loadGoogleFont} from "./services/fontLoader";
 
 /**
  * Main App component responsible for layout and data fetching.
@@ -25,11 +28,16 @@ function App() {
     <AppErrorBoundary>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Box>
-          <Header isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
-          <MainContent/>
-          <Footer />
-        </Box>
+        <Router>
+          <Box>
+            <Header isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
+            <Routes>
+              <Route path="/admin" element={<AdminMain />} />
+              <Route path="/" element={<MainContent />} />
+            </Routes>
+            <Footer />
+          </Box>
+        </Router>
       </ThemeProvider>
     </AppErrorBoundary>
   );

--- a/firebase-android-release-dashboard/src/api/constants.js
+++ b/firebase-android-release-dashboard/src/api/constants.js
@@ -1,0 +1,5 @@
+export const ADD_RELEASES_URL = "https://addReleases-TEMP.run.app/";
+export const DELETE_RELEASE_URL = "https://deleteRelease-TEMP.run.app/";
+export const REFRESH_RELEASE_URL = "https://refreshRelease-TEMP.run.app/";
+export const MODIFY_RELEASE_URL = "https://modifyRelease-TEMP.run.app/";
+export const GET_RELEASES_URL = "https://getReleases-TEMP.run.app/";

--- a/firebase-android-release-dashboard/src/api/index.js
+++ b/firebase-android-release-dashboard/src/api/index.js
@@ -7,6 +7,7 @@ import {
   REFRESH_RELEASE_URL,
   GET_RELEASES_URL,
 } from "./constants";
+import {format} from "date-fns";
 
 const API_DATE_FORMAT = "yyyy-MM-dd";
 

--- a/firebase-android-release-dashboard/src/api/index.js
+++ b/firebase-android-release-dashboard/src/api/index.js
@@ -1,0 +1,140 @@
+import axios from "axios";
+import {auth} from "../firebase";
+import {
+  ADD_RELEASES_URL,
+  DELETE_RELEASE_URL,
+  MODIFY_RELEASE_URL,
+  REFRESH_RELEASE_URL,
+  GET_RELEASES_URL,
+} from "./constants";
+
+const API_DATE_FORMAT = "yyyy-MM-dd";
+
+/**
+ * Add new releases
+ *
+ * This request is only authorized for administrators.
+ *
+ * @param {string} releases - The releases to add to Firestore.
+ * @return {Promise<Object>} - Response object.
+ */
+async function addReleases(releases) {
+  const token = await auth.currentUser.getIdToken();
+  const response = await axios.post(
+      ADD_RELEASES_URL, // TODO: Update URL
+      {
+        releases: releases,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+      },
+  );
+
+  return response;
+};
+
+/**
+ * Delete a release and all its associated data in Firestore.
+ *
+ * This request is only authorized for administrators.
+ *
+ * @param {string} releaseId
+ * @return {Promise<Object>} - Response object.
+ */
+async function deleteRelease(releaseId) {
+  const token = await auth.currentUser.getIdToken();
+  const response = await axios.post(DELETE_RELEASE_URL,
+      {
+        releaseId: releaseId,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+      });
+
+  return response;
+};
+
+/**
+ * Refresh a release and all its associated data in Firestore.
+ *
+ * This request is only authorized for administrators.
+ *
+ * @param {string} releaseId
+ * @return {Promise<Object>} - Response object.
+ */
+async function refreshRelease(releaseId) {
+  const token = await auth.currentUser.getIdToken();
+  const response = await axios.post(REFRESH_RELEASE_URL, {
+    releaseId: releaseId,
+  },
+  {
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`,
+    },
+  });
+
+  return response;
+};
+
+/**
+ * Refresh a release and all its associated data in Firestore.
+ *
+ * This request is only authorized for administrators.
+ *
+ * @param {string} releaseId - The ID of the release to modify.
+ * @param {string} releaseName - The new name of the release.
+ * @param {string} releaseBranchName - The new name of the release branch.
+ * @param {string} releaseOperator - The new operator of the release.
+ * @param {Date} codeFreezeDate - The new code freeze date of the release.
+ * @param {Date} releaseDate - The new release date of the release.
+ * @return {Promise<Object>} - Response object.
+ */
+async function modifyRelease(
+    releaseId,
+    releaseName,
+    releaseBranchName,
+    releaseOperator,
+    codeFreezeDate,
+    releaseDate,
+) {
+  const token = await auth.currentUser.getIdToken();
+  const response = await axios.post(MODIFY_RELEASE_URL, {
+    releaseId: releaseId,
+    release: {
+      releaseName: releaseName,
+      releaseBranchName: releaseBranchName,
+      releaseOperator: releaseOperator,
+      codeFreezeDate: format(codeFreezeDate, API_DATE_FORMAT),
+      releaseDate: format(releaseDate, API_DATE_FORMAT),
+    },
+  },
+  {
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`,
+    },
+  });
+
+  return response;
+};
+
+/**
+ * Refresh a release and all its associated data in Firestore.
+ *
+ * This request is only authorized for administrators.
+ *
+ * @return {Promise<Object>} - Response object.
+ */
+async function getReleases() {
+  const response = await axios.get(GET_RELEASES_URL, {});
+  return response;
+};
+
+export {addReleases, deleteRelease, refreshRelease, modifyRelease, getReleases};

--- a/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseDialog/AddReleaseDialog.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseDialog/AddReleaseDialog.js
@@ -1,0 +1,126 @@
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import PropTypes from "prop-types";
+import React from "react";
+
+
+/**
+ * Dialog for adding new releases.
+ *
+ * @param {bool} open - Whether the dialog is open.
+ * @param {bool} loading - Whether the form is submitting.
+ * @param {bool} formValid - Whether the form is valid.
+ * @param {Object} formData - The data in the form.
+ * @param {function} handleClose - Function to handle a click on the cancel
+ * button.
+ * @param {function} handleChange - Function to handle a change in the form.
+ * @param {function} handleSubmit - Function to handle a click on the submit
+ * button.
+ * @return {JSX.Element} Rendered component.
+ */
+function AddReleaseDialog(
+    {
+      open,
+      loading,
+      formValid,
+      formData,
+      handleClose,
+      handleChange,
+      handleSubmit,
+    },
+) {
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>
+        <Typography variant="h6">
+          Add Release
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          <Typography variant="body1">
+            Please enter the release metadata.
+          </Typography>
+        </DialogContentText>
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseName"
+          label="Release Name"
+          value={formData.releaseName}
+          onChange={handleChange}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseBranchName"
+          label="Release Branch Name"
+          value={formData.releaseBranchName}
+          onChange={handleChange}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="codeFreezeDate"
+          label="Code Freeze Date"
+          type="date"
+          value={formData.codeFreezeDate}
+          onChange={handleChange}
+          InputLabelProps={{shrink: true}}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseDate"
+          label="Release Date"
+          type="date"
+          value={formData.releaseDate}
+          onChange={handleChange}
+          InputLabelProps={{shrink: true}}
+          fullWidth
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary" disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          color="primary"
+          disabled={!formValid || loading}
+        >
+          {loading ? <CircularProgress size={24} /> : "Schedule"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+AddReleaseDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
+  formValid: PropTypes.bool.isRequired,
+  formData: PropTypes.shape({
+    releaseName: PropTypes.string.isRequired,
+    releaseBranchName: PropTypes.string.isRequired,
+    codeFreezeDate: PropTypes.string.isRequired,
+    releaseDate: PropTypes.string.isRequired,
+  }).isRequired,
+  handleClose: PropTypes.func.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+};
+
+export default AddReleaseDialog;

--- a/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseDialog/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseDialog/index.js
@@ -1,0 +1,1 @@
+export {default} from "./AddReleaseDialog";

--- a/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/AddReleaseForm.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/AddReleaseForm.js
@@ -1,0 +1,132 @@
+import {
+  Button,
+  Grid,
+  Typography,
+} from "@material-ui/core";
+import {Add} from "@mui/icons-material";
+import PropTypes from "prop-types";
+import React, {useEffect, useState} from "react";
+import {addReleases} from "../../../api";
+import AddReleaseDialog from "../AddReleaseDialog";
+import useStyles from "./styles";
+
+/**
+ * Form for scheduling new releases.
+ *
+ * Administrators can add new releases by entering the release name,
+ * release branch name, code freeze date, and release date.
+ *
+ * @param {function} openSnackbar - Function to open the snackbar to display
+ * success or error messages.
+ * @return {JSX.Element} - Rendered component.
+ */
+function AddReleaseForm({openSnackbar}) {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [formValid, setFormValid] = useState(false);
+  const [formData, setFormData] = useState({
+    releaseName: "",
+    releaseBranchName: "",
+    releaseOperator: "ACore team member", // Can't store user data
+    codeFreezeDate: "",
+    releaseDate: "",
+  });
+
+  /**
+   * Check if the form is valid every time the form data changes.
+   * The form is valid if all fields are filled out.
+   */
+  useEffect(() => {
+    const isFormValid = Object.values(formData).every((value) => value !== "");
+    setFormValid(isFormValid);
+  }, [formData]);
+
+  const handleClickOpen = () => setOpen(true);
+
+  /**
+   * Close the dialog and reset the form data.
+   */
+  const handleClose = () => {
+    if (!loading) {
+      setOpen(false);
+      setFormData({
+        releaseName: "",
+        releaseBranchName: "",
+        releaseOperator: "ACore team member",
+        codeFreezeDate: "",
+        releaseDate: "",
+      });
+    }
+  };
+
+  /**
+   * Handle a change in the form data by updating the form data state.
+   *
+   * @param {Object} event - The DOM event which triggered the change.
+   */
+  const handleChange = (event) => {
+    setFormData({
+      ...formData,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  /**
+   * Handle a click on the submit button by sending a request to Firebase
+   * Functions to add the release.
+   */
+  const handleSubmit = async () => {
+    setLoading(true);
+    try {
+      const response = await addReleases([formData]);
+      if (response.status === 200) {
+        openSnackbar("Release added successfully", "success");
+        handleClose();
+      }
+    } catch (error) {
+      openSnackbar("Error occurred while scheduling release", "error");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <Button
+        color="primary"
+        onClick={handleClickOpen}
+        className={classes.addReleaseButton}
+      >
+        <Grid container alignItems="center">
+          <Grid item>
+            <Add size={24} className={classes.addIcon}/>
+          </Grid>
+          <Grid item>
+            <Typography
+              variant="subtitle1"
+              color="inherit"
+              className={classes.addReleaseButtonText}
+            >
+            Add release
+            </Typography>
+          </Grid>
+        </Grid>
+      </Button>
+      <AddReleaseDialog
+        open={open}
+        handleClose={handleClose}
+        loading={loading}
+        formValid={formValid}
+        formData={formData}
+        handleChange={handleChange}
+        handleSubmit={handleSubmit}
+      />
+    </>
+  );
+}
+
+AddReleaseForm.propTypes = {
+  openSnackbar: PropTypes.func.isRequired,
+};
+
+export default AddReleaseForm;

--- a/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/index.js
@@ -1,0 +1,1 @@
+export {default} from "./AddReleaseForm";

--- a/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/styles.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AddReleaseForm/styles.js
@@ -1,0 +1,22 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  addReleaseButton: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    padding: theme.spacing(1),
+  },
+  addIcon: {
+    verticalAlign: "middle",
+    marginRight: theme.spacing(0.5),
+    marginLeft: theme.spacing(0.5),
+  },
+  addReleaseButtonText: {
+    verticalAlign: "middle",
+    textTransform: "none",
+    height: "24px",
+    lineHeight: "24px",
+  },
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/AdminMain.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/AdminMain.js
@@ -1,0 +1,67 @@
+import {Box, Container, Paper, Snackbar, Typography} from "@material-ui/core";
+import {Alert} from "@material-ui/lab";
+import React, {useState} from "react";
+import AddReleaseForm from "../AddReleaseForm";
+import ReleaseTable from "../ReleaseTable/ReleaseTable";
+import useStyles from "./styles";
+
+/**
+ * Admin page.
+ *
+ * Displays the admin dashboard, which contains the release scheduling form
+ * and the release table that allows administrators to interact with releases.
+ *
+ * @return {JSX.Element} - Rendered component
+ */
+function AdminMain() {
+  const classes = useStyles();
+  const [snackbarIsOpen, setSnackbarIsOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+  const [snackbarSeverity, setSnackbarSeverity] = useState("");
+
+  /**
+   * Opens the snackbar with the given message and severity.
+   *
+   * @param {string} message - The message to display on the snackbar.
+   * @param {string} severity - The severity of the snackbar message.
+   */
+  const openSnackbar = (message, severity) => {
+    setSnackbarMessage(message);
+    setSnackbarSeverity(severity);
+    setSnackbarIsOpen(true);
+  };
+
+  /**
+   * Closes the snackbar when it is clicked away.
+   *
+   * @param {Object} event - The DOM event which led to the snackbar closing.
+   * @param {string} reason - The reason for the snackbar closing.
+   */
+  const handleSnackbarClose = (event, reason) => {
+    if (reason === "clickaway") return;
+    setSnackbarIsOpen(false);
+  };
+
+  return (
+    <Box className={classes.backdrop}>
+      <Container component={Paper} className={classes.paper}>
+        <Typography variant="h4" className={classes.title}>
+          Release Administration
+        </Typography>
+        <AddReleaseForm openSnackbar={openSnackbar} />
+        <ReleaseTable openSnackbar={openSnackbar} />
+        <Snackbar
+          open={snackbarIsOpen}
+          autoHideDuration={6000}
+          onClose={handleSnackbarClose}
+        >
+          <Alert onClose={handleSnackbarClose} severity={snackbarSeverity}>
+            {snackbarMessage}
+          </Alert>
+        </Snackbar>
+      </Container>
+    </Box>
+  );
+}
+
+export default AdminMain;

--- a/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/index.js
@@ -1,0 +1,1 @@
+export {default} from "./AdminMain";

--- a/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/styles.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/AdminMain/styles.js
@@ -8,8 +8,12 @@ const useStyles = makeStyles((theme) => ({
   },
   paper: {
     padding: "16px",
+    marginTop: theme.spacing(1),
     backgroundColor: theme.palette.background.light,
     maxWidth: "70vw",
+  },
+  title: {
+    marginBottom: "16px",
   },
 }));
 

--- a/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/EditReleaseDialog.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/EditReleaseDialog.js
@@ -1,0 +1,130 @@
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import {format} from "date-fns";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * Dialog to edit release metadata.
+ *
+ * @param {bool} editing - Whether the dialog is open.
+ * @param {Object} editedRelease - The release to edit.
+ * @param {bool} submitting - Whether the form is submitting.
+ * @param {function} handleCancelClick - Function to handle a click on the
+ * cancel button.
+ * @param {function} handleSubmitClick - Function to handle a click on the
+ * submit button.
+ * @param {function} handleChange - Function to handle a change in the form.
+ * @return {JSX.Element} Rendered component.
+ */
+function EditReleaseDialog(
+    {
+      editing,
+      editedRelease,
+      submitting,
+      handleCancelClick,
+      handleSubmitClick,
+      handleChange,
+    },
+) {
+  return (
+    <Dialog open={editing} onClose={handleCancelClick}>
+      <DialogTitle>
+        <Typography variant="h6">
+          Edit Release
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          <Typography variant="body1">
+            Please enter the updated release metadata.
+          </Typography>
+        </DialogContentText>
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseName"
+          label="Release Name"
+          value={editedRelease.releaseName}
+          onChange={handleChange}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseBranchName"
+          label="Release Branch Name"
+          value={editedRelease.releaseBranchName}
+          onChange={handleChange}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="codeFreezeDate"
+          label="Code Freeze Date"
+          type="date"
+          value={format(editedRelease.codeFreezeDate, "yyyy-MM-dd")}
+          onChange={handleChange}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          fullWidth
+        />
+        <TextField
+          margin="dense"
+          variant="outlined"
+          name="releaseDate"
+          label="Release Date"
+          type="date"
+          value={format(editedRelease.releaseDate, "yyyy-MM-dd")}
+          onChange={handleChange}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          fullWidth
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancelClick} color="primary">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmitClick}
+          color="primary"
+          disabled={submitting}
+        >
+          {submitting ? <CircularProgress size={24} /> : "Submit"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+EditReleaseDialog.propTypes = {
+  editing: PropTypes.bool.isRequired,
+  editedRelease: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    releaseName: PropTypes.string.isRequired,
+    codeFreezeDate: PropTypes.instanceOf(Date).isRequired,
+    releaseDate: PropTypes.instanceOf(Date).isRequired,
+    releaseBranchName: PropTypes.string.isRequired,
+    state: PropTypes.string.isRequired,
+  }).isRequired,
+  submitting: PropTypes.bool.isRequired,
+  handleCancelClick: PropTypes.func.isRequired,
+  handleSubmitClick: PropTypes.func.isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default EditReleaseDialog;
+

--- a/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/EditReleaseDialog.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/EditReleaseDialog.js
@@ -99,7 +99,7 @@ function EditReleaseDialog(
           Cancel
         </Button>
         <Button
-          onClick={handleSubmitClick}
+          onClick={() => handleSubmitClick(editedRelease)}
           color="primary"
           disabled={submitting}
         >

--- a/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/EditReleaseDialog/index.js
@@ -1,0 +1,1 @@
+export {default} from "./EditReleaseDialog";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseActionButtons/ReleaseActionButtons.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseActionButtons/ReleaseActionButtons.js
@@ -1,0 +1,72 @@
+import {
+  CircularProgress,
+  IconButton,
+  TableCell,
+  Tooltip,
+} from "@material-ui/core";
+import {Delete, Edit, Sync} from "@mui/icons-material";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * Displays the action buttons for a release row.
+ *
+ * @param {Object} refreshing - Whether the release is being refreshed.
+ * @param {Object} deleting - Whether the release is being deleted.
+ * @param {Function} handleRefreshClick - Function to handle refresh button
+ * click.
+ * @param {Function} handleEditClick - Function to handle edit button click.
+ * @param {Function} handleDeleteClick - Function to handle delete button click.
+ * @return {React.Component}
+ */
+function ReleaseActionButtons(
+    {
+      refreshing,
+      deleting,
+      handleRefreshClick,
+      handleEditClick,
+      handleDeleteClick,
+    },
+) {
+  return (
+    <TableCell>
+      <Tooltip title="Sync with GitHub">
+        <IconButton
+          aria-label="sync"
+          disabled={refreshing}
+          onClick={handleRefreshClick}
+          color="primary"
+        >
+          {refreshing ? <CircularProgress size={24} /> : <Sync />}
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Edit Metadata">
+        <IconButton
+          aria-label="edit"
+          onClick={handleEditClick}
+        >
+          <Edit />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete All Release Data">
+        <IconButton
+          aria-label="delete"
+          disabled={deleting}
+          onClick={handleDeleteClick}
+        >
+          {deleting ? <CircularProgress size={24} /> : <Delete />}
+        </IconButton>
+      </Tooltip>
+    </TableCell>
+  );
+}
+
+ReleaseActionButtons.propTypes = {
+  refreshing: PropTypes.bool.isRequired,
+  deleting: PropTypes.bool.isRequired,
+  handleRefreshClick: PropTypes.func.isRequired,
+  handleEditClick: PropTypes.func.isRequired,
+  handleDeleteClick: PropTypes.func.isRequired,
+};
+
+export default ReleaseActionButtons;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseActionButtons/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseActionButtons/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseActionButtons";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
@@ -75,13 +75,14 @@ function ReleaseRow({releaseId, openSnackbar}) {
    * @param {Object} event - The event that triggered the change.
    */
   const handleChange = (event) => {
+    const {name, value} = event.target;
     const isDateType = ["releaseDate", "codeFreezeDate"]
-        .includes(event.target.name);
+        .includes(name);
 
     setEditedRelease({
       ...editedRelease,
-      [event.target.name]: isDateType ?
-        new Date(event.target.value) : event.target.value,
+      [name]: isDateType ?
+        new Date(value + "T00:00:00") : value,
     });
   };
 

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
@@ -75,18 +75,14 @@ function ReleaseRow({releaseId, openSnackbar}) {
    * @param {Object} event - The event that triggered the change.
    */
   const handleChange = (event) => {
-    if (event.target.name === "releaseDate" ||
-      event.target.name === "codeFreezeDate") {
-      setEditedRelease({
-        ...editedRelease,
-        [event.target.name]: new Date(event.target.value),
-      });
-    } else {
-      setEditedRelease({
-        ...editedRelease,
-        [event.target.name]: event.target.value,
-      });
-    }
+    const isDateType = ["releaseDate", "codeFreezeDate"]
+        .includes(event.target.name);
+
+    setEditedRelease({
+      ...editedRelease,
+      [event.target.name]: isDateType ?
+        new Date(event.target.value) : event.target.value,
+    });
   };
 
   return (

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
@@ -1,0 +1,121 @@
+import {TableRow} from "@material-ui/core";
+import PropTypes from "prop-types";
+import React, {useEffect, useState} from "react";
+import useAdminReleaseActions from "../../../hooks/useAdminReleaseActions";
+import useRelease from "../../../hooks/useRelease";
+import EditReleaseDialog from "../EditReleaseDialog";
+import ReleaseRowContent from "../ReleaseRowContent";
+import useStyles from "./styles";
+
+/**
+ * ReleaseRow component.
+ *
+ * Displays a single release row with the release's metadata and action buttons.
+ * Administrators can edit, refresh, and delete releases.
+ *
+ * @param {Object} releaseID - The ID of the release to display.
+ * @param {Function} openSnackbar - Function to open the snackbar to display
+ * success or error messages.
+ * @return {JSX.Element} Rendered component.
+ */
+function ReleaseRow({releaseId, openSnackbar}) {
+  const classes = useStyles();
+  const release = useRelease(releaseId);
+  const [editing, setEditing] = useState(false);
+  const [editedRelease, setEditedRelease] = useState(null);
+
+  // State and handlers for administrator release actions
+  const {
+    deleting,
+    refreshing,
+    submitting,
+    handleDeleteClick,
+    handleRefreshClick,
+    handleSubmitClick,
+  } = useAdminReleaseActions(release, openSnackbar, setEditing);
+
+  /**
+   * Set the edited release state to the release state when the release state
+   * changes. This is necessary because the release state is fetched from
+   * Firestore asynchronously, and the edited release state is initialized to
+   * null. If the release state is updated after the edited release state is
+   * initialized, we need to update the edited release state to the new release
+   * state.
+   */
+  useEffect(() => {
+    setEditedRelease(release);
+  }, [release]);
+
+  // This only occurs when the release has not been fetched from Firestore yet
+  if (!release || !editedRelease) {
+    return null;
+  }
+
+  /**
+   * Handle a click on the edit button by setting the editing state to true.
+   * This will display the edit release dialog.
+   */
+  const handleEditClick = () => {
+    setEditing(true);
+  };
+
+  /**
+   * Handle a click on the cancel button by setting the editing state to false
+   * and resetting the edited release state to the original release state.
+   */
+  const handleCancelClick = () => {
+    setEditing(false);
+    setEditedRelease(release);
+  };
+
+  /**
+   * Handle a change in the edit release form by updating the edited release
+   * state.
+   *
+   * @param {Object} event - The event that triggered the change.
+   */
+  const handleChange = (event) => {
+    if (event.target.name === "releaseDate" ||
+      event.target.name === "codeFreezeDate") {
+      setEditedRelease({
+        ...editedRelease,
+        [event.target.name]: new Date(event.target.value),
+      });
+    } else {
+      setEditedRelease({
+        ...editedRelease,
+        [event.target.name]: event.target.value,
+      });
+    }
+  };
+
+  return (
+    <>
+      <TableRow className={classes.tableRow}>
+        <ReleaseRowContent
+          release={release}
+          refreshing={refreshing}
+          deleting={deleting}
+          handleRefreshClick={handleRefreshClick}
+          handleEditClick={handleEditClick}
+          handleDeleteClick={handleDeleteClick}
+        />
+      </TableRow>
+      <EditReleaseDialog
+        editing={editing}
+        editedRelease={editedRelease}
+        submitting={submitting}
+        handleCancelClick={handleCancelClick}
+        handleSubmitClick={handleSubmitClick}
+        handleChange={handleChange}
+      />
+    </>
+  );
+}
+
+ReleaseRow.propTypes = {
+  releaseId: PropTypes.string.isRequired,
+  openSnackbar: PropTypes.func.isRequired,
+};
+
+export default ReleaseRow;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseRow";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/styles.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/styles.js
@@ -1,0 +1,11 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  tableRow: {
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover, // hover effect
+    },
+  },
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
@@ -1,0 +1,89 @@
+import {TableCell, Typography} from "@material-ui/core";
+import {format} from "date-fns";
+import PropTypes from "prop-types";
+import React from "react";
+import {RELEASE_STATES} from "../../../utils/releaseStates";
+import StateChip from "../../Release/StateChip/StateChip";
+import ReleaseActionButtons from "../ReleaseActionButtons/ReleaseActionButtons";
+
+/**
+ * Displays the release's metadata in table cells.
+ *
+ * @param {Object} release - Release object
+ * @param {string} release.id - Release ID.
+ * @param {string} release.releaseName - Release name.
+ * @param {Date} release.codeFreezeDate - Code freeze date.
+ * @param {Date} release.releaseDate - Release date.
+ * @param {string} release.releaseBranchName - Release branch name.
+ * @param {string} release.state - Release state.
+ * @param {boolean} refreshing - Whether the release is being refreshed.
+ * @param {boolean} deleting - Whether the release is being deleted.
+ * @param {Function} handleRefreshClick - Function to handle refresh button
+ * click.
+ * @param {Function} handleEditClick - Function to handle edit button click.
+ * @param {Function} handleDeleteClick - Function to handle delete button click.
+ * @return {JSX.Element} Rendered component.
+ */
+function ReleaseRowContent(
+    {
+      release,
+      refreshing,
+      deleting,
+      handleRefreshClick,
+      handleEditClick,
+      handleDeleteClick,
+    },
+) {
+  return (
+    <>
+      <TableCell>
+        <Typography variant="body1" color="textPrimary">
+          {release.releaseName}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Typography variant="body2" color="textPrimary">
+          {format(release.codeFreezeDate, "MMM. dd, yyyy")}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Typography variant="body2" color="textPrimary">
+          {format(release.releaseDate, "MMM. dd, yyyy")}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Typography variant="body2" color="textPrimary">
+          {release.releaseBranchName}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <StateChip state={release.state} />
+      </TableCell>
+      <ReleaseActionButtons
+        refreshing={refreshing}
+        deleting={deleting}
+        handleRefreshClick={handleRefreshClick}
+        handleEditClick={handleEditClick}
+        handleDeleteClick={handleDeleteClick}
+      />
+    </>
+  );
+}
+
+ReleaseRowContent.propTypes = {
+  release: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    releaseName: PropTypes.string.isRequired,
+    codeFreezeDate: PropTypes.instanceOf(Date).isRequired,
+    releaseDate: PropTypes.instanceOf(Date).isRequired,
+    releaseBranchName: PropTypes.string.isRequired,
+    state: PropTypes.oneOf(Object.values(RELEASE_STATES)).isRequired,
+  }).isRequired,
+  refreshing: PropTypes.bool.isRequired,
+  deleting: PropTypes.bool.isRequired,
+  handleRefreshClick: PropTypes.func.isRequired,
+  handleEditClick: PropTypes.func.isRequired,
+  handleDeleteClick: PropTypes.func.isRequired,
+};
+
+export default ReleaseRowContent;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseRowContent";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/ReleaseTable.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/ReleaseTable.js
@@ -1,0 +1,73 @@
+import {
+  Table, TableBody,
+  TableCell,
+  TableContainer,
+  TableHead, TableRow, Typography,
+} from "@material-ui/core";
+import PropTypes from "prop-types";
+import React from "react";
+import useReleases from "../../../hooks/useReleases";
+import ReleaseRow from "../ReleaseRow/ReleaseRow";
+import useStyles from "./styles";
+
+const tableHeaders = [
+  "Release Name",
+  "Code Freeze Date",
+  "Release Date",
+  "Release Branch",
+  "State",
+  "", // Buttons
+];
+
+/**
+ * Displays a table of releases. Each row in the table is a ReleaseRow
+ * component which displays information about a release and allows the user
+ * to edit, delete or refresh the release by sending requests to Firebase
+ * Functions.
+ *
+ * @param {function} openSnackbar - Function to open the snackbar to display
+ * success or error messages.
+ * @return {JSX.Element} Rendered AdminReleaseTable component.
+ */
+function ReleaseTable({openSnackbar}) {
+  const classes = useStyles();
+  const releases = useReleases(null, null);
+
+  return (
+    <div className={classes.container}>
+      <TableContainer className={classes.tableContainer}>
+        <Table className={classes.table}>
+          <TableHead>
+            <TableRow>
+              {tableHeaders.map((header) => (
+                <TableCell key={header}>
+                  <Typography
+                    variant="body1"
+                    className={classes.tableHeader}
+                  >
+                    {header}
+                  </Typography>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {releases.map((release) => (
+              <ReleaseRow
+                key={release.id}
+                releaseId={release.id}
+                openSnackbar={openSnackbar}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </div>
+  );
+}
+
+ReleaseTable.propTypes = {
+  openSnackbar: PropTypes.func.isRequired,
+};
+
+export default ReleaseTable;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseTable";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/styles.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseTable/styles.js
@@ -1,0 +1,24 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  table: {
+    minWidth: 650,
+  },
+  tableContainer: {
+    borderRadius: 5,
+    backgroundColor: theme.palette.background.paper,
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    maxWidth: "90vw",
+    boxShadow: theme.shadows[2],
+  },
+  container: {
+    display: "flex",
+    justifyContent: "center",
+  },
+  tableHeader: {
+    fontWeight: theme.typography.fontWeightBold,
+  },
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/components/Header/Header.js
+++ b/firebase-android-release-dashboard/src/components/Header/Header.js
@@ -1,15 +1,15 @@
-import React, {useState} from "react";
-import PropTypes from "prop-types";
 import {
   AppBar,
   Button,
   Toolbar,
   Typography,
 } from "@material-ui/core";
+import PropTypes from "prop-types";
+import React, {useState} from "react";
 import Modal from "react-modal";
 
-import {auth} from "../../firebase";
 import firebaseLogo from "../../assets/logo.svg";
+import {auth} from "../../firebase";
 import SignInDialog from "../SignInDialog";
 import useStyles from "./styles";
 
@@ -42,10 +42,21 @@ function Header({isLoggedIn, setIsLoggedIn}) {
   };
 
   const renderButton = () => {
+    const isOnAdminPage = location.pathname === "/admin";
+
     return isLoggedIn ? (
-      <Button className={classes.button} onClick={handleLogout}>
+      <>
+        <Button
+          className={classes.button}
+          href="/admin"
+          disabled={isOnAdminPage}
+        >
+        Admin
+        </Button>
+        <Button className={classes.button} onClick={handleLogout}>
         Logout
-      </Button>
+        </Button>
+      </>
     ) : (
       <Button className={classes.button} onClick={handleLogin}>
         Login
@@ -56,7 +67,9 @@ function Header({isLoggedIn, setIsLoggedIn}) {
   return (
     <AppBar position="static" className={classes.appBar}>
       <Toolbar>
-        <img src={firebaseLogo} alt="Firebase" className={classes.logo}/>
+        <a href="/">
+          <img src={firebaseLogo} alt="Firebase" className={classes.logo}/>
+        </a>
         <Typography variant="h5" color="textPrimary" className={classes.title}>
           Firebase Android Release Dashboard
         </Typography>

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/ReleaseMetadata.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/ReleaseMetadata.js
@@ -1,27 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {Grid, Chip, Typography} from "@material-ui/core";
+import {Grid, Typography} from "@material-ui/core";
 import {format} from "date-fns";
 import {RELEASE_STATES} from "../../../utils/releaseStates";
-import theme from "../../../config/theme";
 import useStyles from "./styles";
-
-const chipColor = (state) => {
-  switch (state) {
-    case RELEASE_STATES.CODE_FREEZE:
-      return theme.palette.chip.blue;
-    case RELEASE_STATES.RELEASE_DAY:
-      return theme.palette.chip.purple;
-    case RELEASE_STATES.RELEASED:
-      return theme.palette.chip.green;
-    case RELEASE_STATES.DELAYED:
-      return theme.palette.chip.orange;
-    case RELEASE_STATES.ERROR:
-      return theme.palette.chip.error;
-    default:
-      return theme.palette.chip.gray;
-  }
-};
+import StateChip from "../StateChip/StateChip";
 
 /**
  * Represents the metadata of a single release.
@@ -74,11 +57,7 @@ function ReleaseMetadata({release}) {
         </Typography>
       </Grid>
       <Grid item xs={3}>
-        <Chip
-          label={state}
-          className={classes.stateChip}
-          style={{backgroundColor: chipColor(state)}}
-        />
+        <StateChip state={state} />
       </Grid>
     </Grid>
   );

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/styles.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/styles.js
@@ -10,11 +10,6 @@ const useStyles = makeStyles({
     flex: "1 0 20%",
     textAlign: "left",
   },
-  stateChip: {
-    padding: theme.spacing(0.5),
-    color: theme.palette.primary.contrastText,
-    fontWeight: 450,
-  },
 });
 
 export default useStyles;

--- a/firebase-android-release-dashboard/src/components/Release/StateChip/StateChip.js
+++ b/firebase-android-release-dashboard/src/components/Release/StateChip/StateChip.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {Chip} from "@material-ui/core";
+import {RELEASE_STATES} from "../../../utils/releaseStates";
+import useStyles from "./styles";
+import theme from "../../../config/theme";
+
+const chipColor = (state) => {
+  const color = theme.palette.primary.contrastText;
+  const stateColors = {
+    [RELEASE_STATES.CODE_FREEZE]: theme.palette.chip.blue,
+    [RELEASE_STATES.RELEASE_DAY]: theme.palette.chip.purple,
+    [RELEASE_STATES.RELEASED]: theme.palette.chip.green,
+    [RELEASE_STATES.DELAYED]: theme.palette.chip.orange,
+    [RELEASE_STATES.ERROR]: theme.palette.chip.error,
+  };
+
+  const backgroundColor = stateColors[state] || theme.palette.chip.gray;
+
+  return {backgroundColor, color};
+};
+
+/**
+ * Returns a chip containing the state of the release.
+ *
+ * @param {string} state - The state of the release.
+ * @return {JSX.Element} The StateChip component.
+ */
+function StateChip({state}) {
+  const styles = chipColor(state);
+  const classes = useStyles(styles);
+
+  return (
+    <Chip
+      label={state}
+      className={classes.stateChip}
+      styles={chipColor(state)}
+    />
+  );
+}
+
+StateChip.propTypes = {
+  state: PropTypes.oneOf(Object.values(RELEASE_STATES)).isRequired,
+};
+
+export default StateChip;

--- a/firebase-android-release-dashboard/src/components/Release/StateChip/index.js
+++ b/firebase-android-release-dashboard/src/components/Release/StateChip/index.js
@@ -1,0 +1,1 @@
+export {default} from "./StateChip";

--- a/firebase-android-release-dashboard/src/components/Release/StateChip/styles.js
+++ b/firebase-android-release-dashboard/src/components/Release/StateChip/styles.js
@@ -1,0 +1,13 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  stateChip: (props) => ({
+    backgroundColor: props.backgroundColor,
+    color: props.color,
+    padding: theme.spacing(0.5),
+    color: theme.palette.primary.contrastText,
+    fontWeight: 450,
+  }),
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/config/theme.js
+++ b/firebase-android-release-dashboard/src/config/theme.js
@@ -6,26 +6,19 @@ const theme = createTheme({
   typography: {
     fontFamily: "\"Google Sans\", Arial, sans-serif",
     h6: {
-      // fontSize: "16px",
       fontFamily: "\"Google Sans\", Arial, sans-serif",
     },
     body1: {
-      // fontSize: "14px",
       fontFamily: "\"Roboto\", Arial, sans-serif",
     },
     body2: {
-      // fontSize: "12px",
       fontFamily: "\"Roboto\", Arial, sans-serif",
     },
     subtitle1: {
       fontFamily: "\"Google Sans\", Arial, sans-serif",
-      // fontSize: "16px",
-      // fontWeight: 400,
     },
     subtitle2: {
       fontFamily: "\"Google Sans\", Arial, sans-serif",
-      // fontSize: "20px",
-      // fontWeight: 300,
     },
   },
   palette: {

--- a/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
+++ b/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
@@ -1,0 +1,101 @@
+import {useState} from "react";
+import {deleteRelease, modifyRelease, refreshRelease} from "../api";
+
+/**
+ * Custom React hook to handle administrator release actions.
+ *
+ * Returns the state and handlers for deleting, refreshing, and submitting
+ * a single release. These handlers are passed to buttons that allow the
+ * administrator to perform these actions.
+ *
+ * @param {Object} release - The release object.
+ * @param {Function} openSnackbar - Function to open the snackbar.
+ * @param {Function} setEditing - Function to set the editing state.
+ * @return {Object} An object containing states and handler functions for
+ * release actions.
+ */
+const useReleaseActions = (release, openSnackbar, setEditing) => {
+  const [deleting, setDeleting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  /**
+   * Handle a click on the delete button by calling the deleteRelease API
+   */
+  const handleDeleteClick = async () => {
+    setDeleting(true);
+    try {
+      const response = await deleteRelease(release.id);
+      if (response.status === 200) {
+        openSnackbar("Release deleted successfully", "success");
+      } else {
+        openSnackbar("Failed to delete release", "error");
+      }
+    } catch (error) {
+      // TODO: Fetch full error from Firestore, and display it
+      openSnackbar("Error occurred while deleting release", "error");
+    }
+    setDeleting(false);
+  };
+
+  /**
+   * Handle a click on the refresh button by calling the refreshRelease API
+   */
+  const handleRefreshClick = async () => {
+    setRefreshing(true);
+    try {
+      const response = await refreshRelease(release.id);
+      console.log("ok", response.status === 200);
+      if (response.status === 200) {
+        openSnackbar("Release refreshed successfully", "success");
+      } else {
+        openSnackbar("Failed to refresh release", "error");
+      }
+    } catch (error) {
+      // TODO: Fetch full error from Firestore, and display it
+      openSnackbar("Error occurred while refreshing release", "error");
+    }
+    setRefreshing(false);
+  };
+
+  /**
+   * Handle a submission of edited release data, and update the release
+   * with the modifyRelease API.
+   *
+   * @param {Object} editedRelease
+   */
+  const handleSubmitClick = async (editedRelease) => {
+    setSubmitting(true);
+    try {
+      const response = await modifyRelease(
+          release.id,
+          editedRelease.releaseName,
+          editedRelease.releaseBranchName,
+          "ACore team member", // TODO: Replace with actual operator
+          editedRelease.codeFreezeDate,
+          editedRelease.releaseDate,
+      );
+      if (response.status === 200) {
+        openSnackbar("Release modified successfully", "success");
+        setEditing(false);
+      } else {
+        openSnackbar("Failed to modify release", "error");
+      }
+    } catch (error) {
+      // TODO: Fetch full error from Firestore, and display it
+      openSnackbar("Error occurred while modifying release", "error");
+    }
+    setSubmitting(false);
+  };
+
+  return {
+    deleting,
+    refreshing,
+    submitting,
+    handleDeleteClick,
+    handleRefreshClick,
+    handleSubmitClick,
+  };
+};
+
+export default useReleaseActions;

--- a/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
+++ b/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
@@ -45,7 +45,6 @@ const useReleaseActions = (release, openSnackbar, setEditing) => {
     setRefreshing(true);
     try {
       const response = await refreshRelease(release.id);
-      console.log("ok", response.status === 200);
       if (response.status === 200) {
         openSnackbar("Release refreshed successfully", "success");
       } else {

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -33,6 +33,7 @@ const {
   validateRelease,
 } = require("../validation/validation.js");
 const {
+  convertSingleReleaseDatesToTimestamps,
   convertReleaseDatesToTimestamps,
   processLibraryNames,
   calculateReleaseState,
@@ -389,15 +390,13 @@ async function modifyRelease(req, res) {
 
     const octokit = new Octokit({auth: GITHUB_TOKEN.value()});
 
-    let releasesWithConvertedDates;
+    let release;
     try {
-      releasesWithConvertedDates = convertReleaseDatesToTimestamps(releaseData);
+      release = convertSingleReleaseDatesToTimestamps(releaseData);
     } catch (err) {
       warn("Error while converting dates to timestamps", {error: err.message});
       return res.status(500).send("Internal Server Error");
     }
-
-    const release = releasesWithConvertedDates[0];
 
     // Update the release data in Firestore
     try {

--- a/functions/test/utils/utils.test.js
+++ b/functions/test/utils/utils.test.js
@@ -1,5 +1,6 @@
 const {
   convertDateToTimestamp,
+  convertSingleReleaseDatesToTimestamps,
   convertReleaseDatesToTimestamps,
   parseGradlePropertiesForVersion,
   calculateReleaseState,
@@ -23,6 +24,35 @@ describe("convertDateToTimestamp", () => {
     const consoleErrorStub = sinon.stub(console, "error");
     expect(() => convertDateToTimestamp(dateString)).to.throw();
     consoleErrorStub.restore();
+  });
+});
+
+describe("convertSingleReleaseDatesToTimestamps", () => {
+  it("should correctly convert date strings to Firestore Timestamps", () => {
+    const release = {
+      name: "Release 1",
+      codeFreezeDate: "2023-07-19",
+      releaseDate: "2023-08-19",
+    };
+
+    const result = convertSingleReleaseDatesToTimestamps(release);
+
+    expect(result).to.have.property("codeFreezeDate");
+    expect(result.codeFreezeDate).to.be.an
+        .instanceof(Timestamp);
+    expect(result).to.have.property("releaseDate");
+    expect(result.releaseDate).to.be.an
+        .instanceof(Timestamp);
+  });
+
+  it("should not convert if date properties are not present", () => {
+    const release = {
+      name: "Release 1",
+    };
+
+    const result = convertSingleReleaseDatesToTimestamps(release);
+
+    expect(result).to.deep.equal(release);
   });
 });
 

--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -26,6 +26,23 @@ function convertDateToTimestamp(dateString) {
 }
 
 /**
+ * Convert release dates from strings to Firestore Timestamps
+ * for a single release.
+ *
+ * @param {Object} release - The release to convert.
+ * @return {Object} The release with the converted dates.
+ */
+function convertSingleReleaseDatesToTimestamps(release) {
+  const convertedRelease = {...release};
+  ["codeFreezeDate", "releaseDate"].forEach((dateType) => {
+    if (release[dateType]) {
+      convertedRelease[dateType] = convertDateToTimestamp(release[dateType]);
+    }
+  });
+  return convertedRelease;
+}
+
+/**
  * Convert release dates from strings to Firestore Timestamps.
  *
  * @param {Object[]} releases - The releases to convert.
@@ -33,13 +50,7 @@ function convertDateToTimestamp(dateString) {
  */
 function convertReleaseDatesToTimestamps(releases) {
   return releases.map((release) => {
-    const convertedRelease = {...release};
-    ["codeFreezeDate", "releaseDate"].forEach((dateType) => {
-      if (release[dateType]) {
-        convertedRelease[dateType] = convertDateToTimestamp(release[dateType]);
-      }
-    });
-    return convertedRelease;
+    return convertSingleReleaseDatesToTimestamps(release);
   });
 }
 
@@ -196,6 +207,7 @@ function filterOutKtx(libaries) {
 
 module.exports = {
   convertDateToTimestamp,
+  convertSingleReleaseDatesToTimestamps,
   convertReleaseDatesToTimestamps,
   parseGradlePropertiesForVersion,
   calculateReleaseState,


### PR DESCRIPTION
- Routing to Admin page (if signed in) using the [React Router](https://reactrouter.com/en/main)
- Displaying all release metadata in table format (not releases, changes, checks, since those are not editable)
- Each release can be interacted with using buttons for sync, edit, delete
- Releases can be added one at a time by filling out the add release form
- Error and success messages are displayed in a [snackbar](https://mui.com/material-ui/react-snackbar/)

Future Improvements:
- Stack trace on errors rather than opaque error messages
- Batch add release (from CSV)
- Restrict the /admin page to only be accessible to signed in users (the nav button isn't currently displayed, but a user that is signed out can still manually access that URL) using [ProtectedRoute](https://www.robinwieruch.de/react-router-private-routes/)

The live version is not out yet since this relies on functions, which I don't have permission to deploy yet. I can share some screenshots in the meantime
![1](https://github.com/firebase/firebase-release-dashboard/assets/64338275/d1142c1f-dc8e-43c5-abbe-346f876ae722)
![2](https://github.com/firebase/firebase-release-dashboard/assets/64338275/3d213e0a-0747-4241-8460-519606ffd552)
![3](https://github.com/firebase/firebase-release-dashboard/assets/64338275/18f04f07-2abb-4840-804c-0165bc328223)
