### PR TITLE
Release state notifications

### DIFF
--- a/firebase-android-release-dashboard/src/App.js
+++ b/firebase-android-release-dashboard/src/App.js
@@ -8,6 +8,7 @@ import MainContent from "./components/MainContent";
 import theme from "./config/theme";
 import {loadGoogleFont} from "./services/fontLoader";
 import {useAuthentication} from "./hooks/useAuthentication";
+import ReleaseNotifier from "./components/ReleaseNotifier/ReleaseNotifier";
 
 /**
  * Main App component responsible for layout and data fetching.
@@ -25,6 +26,7 @@ function App() {
     <AppErrorBoundary>
       <ThemeProvider theme={theme}>
         <CssBaseline />
+        <ReleaseNotifier />
         <Box>
           <Header isLoggedIn={isLoggedIn} setIsLoggedIn={setIsLoggedIn}/>
           <MainContent/>

--- a/firebase-android-release-dashboard/src/components/NotificationRequester/NotificationRequester.js
+++ b/firebase-android-release-dashboard/src/components/NotificationRequester/NotificationRequester.js
@@ -1,0 +1,16 @@
+import {useEffect} from "react";
+
+/**
+ * Component that requests permission to send notifications when mounted.
+ *
+ * @return {JSX.Element}
+ */
+function NotificationRequester() {
+  useEffect(() => {
+    Notification.requestPermission();
+  }, []);
+
+  return null; // This component doesn't render anything
+};
+
+export default NotificationRequester;

--- a/firebase-android-release-dashboard/src/components/NotificationRequester/index.js
+++ b/firebase-android-release-dashboard/src/components/NotificationRequester/index.js
@@ -1,0 +1,1 @@
+export {default} from "./NotificationRequester";

--- a/firebase-android-release-dashboard/src/components/ReleaseNotifier/ReleaseNotifier.js
+++ b/firebase-android-release-dashboard/src/components/ReleaseNotifier/ReleaseNotifier.js
@@ -1,0 +1,46 @@
+import React, {useEffect} from "react";
+import useReleaseStateUpdates from "../../hooks/useReleaseStateUpdates";
+import NotificationRequester from "../NotificationRequester";
+import {RELEASE_STATES} from "../../utils/releaseStates";
+
+const stateUpdateMesssage = (releaseName, state) => {
+  switch (state) {
+    case RELEASE_STATES.CODE_FREEZE:
+      return `Release ${releaseName} has entered code freeze.`;
+    case RELEASE_STATES.RELEASE_DAY:
+      return `Release ${releaseName} is scheduled to be released today.`;
+    case RELEASE_STATES.RELEASED:
+      return `Release ${releaseName} has been released.`;
+    case RELEASE_STATES.DELAYED:
+      return `Release ${releaseName} has been delayed.`;
+    default:
+      return `Release ${releaseName} has been updated to ${state}.`;
+  }
+};
+/**
+ * Component to display notifications for release state updates.
+ *
+ * @return {JSX.Element} The rendered ReleaseNotifier component
+ */
+function ReleaseNotifier() {
+  const releasesWithStateUpdates = useReleaseStateUpdates();
+
+  useEffect(() => {
+    releasesWithStateUpdates.forEach((release) => {
+      if (release.state !== RELEASE_STATES.ERROR &&
+        release.state !== RELEASE_STATES.UPCOMING) {
+        new Notification("Release Update", {
+          body: stateUpdateMesssage(release.releaseName, release.state),
+        });
+      }
+    });
+  }, [releasesWithStateUpdates]);
+
+  return (
+    <>
+      <NotificationRequester />
+    </>
+  );
+}
+
+export default ReleaseNotifier;

--- a/firebase-android-release-dashboard/src/components/ReleaseNotifier/index.js
+++ b/firebase-android-release-dashboard/src/components/ReleaseNotifier/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseNotifier";

--- a/firebase-android-release-dashboard/src/hooks/useReleaseStateUpdates.js
+++ b/firebase-android-release-dashboard/src/hooks/useReleaseStateUpdates.js
@@ -1,0 +1,68 @@
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+} from "firebase/firestore";
+import {useEffect, useRef, useState} from "react";
+import {db} from "../firebase";
+
+/**
+ * Custom hook to get releases with state updates.
+ *
+ * This hook uses the Firestore onSnapshot listener to get updates to the
+ * releases collection. It then filters the updates to only include releases
+ * that have had their state changed.
+ *
+ * @return {Array} The releases with state updates
+ */
+function useReleaseStateUpdates() {
+  const [releasesWithStateUpdates, setReleasesWithStateUpdates] = useState([]);
+  const previousStates = useRef({});
+
+  useEffect(() => {
+    const releasesCollection = collection(db, "releases");
+    const releasesQuery = query(releasesCollection,
+        orderBy("releaseDate", "desc"));
+
+    const unsubscribe = onSnapshot(releasesQuery, (snapshot) => {
+      let updatedReleases = [];
+
+      snapshot.docChanges().forEach((change) => {
+        const data = change.doc.data();
+        const id = change.doc.id;
+
+        // Only process modified documents.
+        if (previousStates.current.hasOwnProperty(id) &&
+          (change.type === "modified" &&
+            (previousStates.current[id] !== data.state))) {
+          // Update releases
+          updatedReleases = [
+            ...updatedReleases.filter((release) => release.id !== id),
+            {
+
+              id,
+              ...data,
+              // Convert Firestore Timestamp to JS Date object
+              releaseDate: data.releaseDate.toDate(),
+              codeFreezeDate: data.codeFreezeDate.toDate(),
+            },
+          ];
+        }
+
+        if (change.type == "modified" || change.type == "added") {
+          previousStates.current[id] = data.state;
+        }
+      });
+
+      setReleasesWithStateUpdates(updatedReleases);
+    });
+
+    // Clean up the onSnapshot listener when the component is unmounted
+    return () => unsubscribe();
+  }, []); // Empty array to ensure the effect only runs once on component mount
+
+  return releasesWithStateUpdates;
+}
+
+export default useReleaseStateUpdates;


### PR DESCRIPTION
Notify users when a release enters code freeze, is on release day, has been released, or has been delayed (don't notify when releases have been scheduled, or enter the error state).

Note: notifications are sent to administrators, which could be annoying when they're interacting with releases. For example, if a release operator fixes and syncs a release after it was in an error state, they'll get notifications for that. I think this could be fixed if we only mount the notification component on the main page, and not the admin page. 