### PR TITLE
Store stack traces for release sync errors

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -11,6 +11,7 @@ const {
 } = require("../utils/utils.js");
 const {REPO_URL} = require("../github/github.js");
 const {warn} = require("firebase-functions/logger");
+const {Timestamp} = require("firebase-admin/firestore");
 
 /**
  * Check if a release document with a given releaseId exists in Firestore.
@@ -530,6 +531,25 @@ async function deleteAllReleaseData(releaseId) {
   await batch.commit();
 }
 
+/**
+ * Stores a stack trace in Firestore.
+ *
+ * @param {string} releaseId The ID of the release to store the stack trace for.
+ * @param {string} errorMsg The error message to store.
+ * @param {string} stackTrace The stack trace to store.
+ * @param {string} contextMsg Context surrounding the error.
+ */
+async function setReleaseError(releaseId, errorMsg, stackTrace, contextMsg) {
+  const timestamp = Timestamp.now();
+
+  await db.collection("releaseError").add({
+    releaseID: releaseId,
+    stackTrace: stackTrace,
+    contextMsg: contextMsg,
+    timestamp: timestamp,
+  });
+}
+
 module.exports = {
   releaseExists,
   setReleases,
@@ -543,4 +563,5 @@ module.exports = {
   getReleaseData,
   updateCheckRunStatus,
   deleteAllReleaseData,
+  setReleaseError,
 };

--- a/functions/github/github.js
+++ b/functions/github/github.js
@@ -1,4 +1,4 @@
-const {log, error} = require("firebase-functions/logger");
+const {log} = require("firebase-functions/logger");
 const {parseGradlePropertiesForVersion} = require("../utils/utils.js");
 const crypto = require("crypto");
 
@@ -13,33 +13,26 @@ const REPO_URL = `https://github.com/${OWNER}/${REPO}`;
  * @param {Octokit} octokit The authenticated Octokit instance.
  * @param {string} ref The git reference (typically a branch or tag).
  * @param {string} path The path to the file within the repository.
+ * @throws {Error} If the request fails.
  * @return {Promise<string>} The file's content as a string.
  */
 async function getRepositoryContent(octokit, ref, path) {
   log("fetching repository content", {ref: ref, path: path});
-  try {
-    // Fetch the file from the GitHub repository
-    const response = await octokit.request(
-        "GET /repos/{owner}/{repo}/contents/{path}", {
-          owner: OWNER,
-          repo: REPO,
-          path: path,
-          ref: ref,
-          headers: {
-            "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
-          },
-        });
+  // Fetch the file from the GitHub repository
+  const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/contents/{path}", {
+        owner: OWNER,
+        repo: REPO,
+        path: path,
+        ref: ref,
+        headers: {
+          "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
+        },
+      });
 
-    // Decode the file content (which is base64 encoded by GitHub)
-    const content = Buffer.from(response.data.content, "base64").toString();
-    return content;
-  } catch (err) {
-    error(
-        `Error fetching ${path} on ${ref} from GitHub:`,
-        {error: err.message},
-    );
-    throw err;
-  }
+  // Decode the file content (which is base64 encoded by GitHub)
+  const content = Buffer.from(response.data.content, "base64").toString();
+  return content;
 }
 
 /**
@@ -47,30 +40,23 @@ async function getRepositoryContent(octokit, ref, path) {
  *
  * @param {Octokit} octokit The authenticated Octokit instance.
  * @param {String} ref The git reference (typically a branch or tag).
+ * @throws {Error} If the request fails.
  * @return {Promise<Array>} An array of check run objects.
  */
 async function listCheckRuns(octokit, ref) {
-  try {
-    // Fetch the list of check runs for the git reference
-    const checkRuns = await octokit.paginate(
-        "GET /repos/{owner}/{repo}/commits/{ref}/check-runs", {
-          owner: OWNER,
-          repo: REPO,
-          ref: ref,
-          headers: {
-            "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
-          },
-          per_page: 100,
-        });
+  // Fetch the list of check runs for the git reference
+  const checkRuns = await octokit.paginate(
+      "GET /repos/{owner}/{repo}/commits/{ref}/check-runs", {
+        owner: OWNER,
+        repo: REPO,
+        ref: ref,
+        headers: {
+          "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
+        },
+        per_page: 100,
+      });
 
-    return checkRuns;
-  } catch (err) {
-    error(
-        `Error fetching check suites on ${ref} from GitHub:`,
-        {error: err.message},
-    );
-    throw err;
-  }
+  return checkRuns;
 }
 
 /**
@@ -169,7 +155,7 @@ async function getLibraryMetadata(
         "updatedVersion": libraryVersions[library],
         "optedIn": !libraryChanges[library],
         "libraryGroupRelease": !libraryChanges[library] ||
-        libraryChanges[library].length === 0,
+          libraryChanges[library].length === 0,
       };
     }
   }
@@ -196,7 +182,7 @@ async function getLibraryVersions(octokit, releaseBranchName, libraryNames) {
   // Perform all requests in parallel.
   const promises = libraryNames.map(async (library) => {
     const gradleDir = library.endsWith("/ktx") ?
-        library.replace("/ktx", "") : library;
+      library.replace("/ktx", "") : library;
 
     const gradleProperties = await getRepositoryContent(
         octokit, releaseBranchName,
@@ -216,26 +202,23 @@ async function getLibraryVersions(octokit, releaseBranchName, libraryNames) {
  *
  * @param {Octokit} octokit The authenticated Octokit client.
  * @param {string} releaseBranchName The name of the release branch to check.
+ * @throws {Error} If the request fails. If the branch does not exist, the
+ * request will fail with a 404 error.
  * @return {Promise<boolean>} A promise that resolves to true if the branch
  * exists, false otherwise.
  */
-async function checkReleaseBranchExists(octokit, releaseBranchName) {
-  try {
-    await octokit.request(
-        "GET /repos/{owner}/{repo}/branches/{branch}", {
-          owner: OWNER,
-          repo: REPO,
-          branch: releaseBranchName,
-          headers: {
-            "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
-          },
-        });
-  } catch (err) {
-    error("error occured while checking if release branch exists",
-        {error: err.message});
-    return false;
-  }
+async function getReleaseBranch(octokit, releaseBranchName) {
+  await octokit.request(
+      "GET /repos/{owner}/{repo}/branches/{branch}", {
+        owner: OWNER,
+        repo: REPO,
+        branch: releaseBranchName,
+        headers: {
+          "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
+        },
+      });
 
+  // If the request succeeds, the branch exists
   return true;
 }
 
@@ -244,35 +227,31 @@ async function checkReleaseBranchExists(octokit, releaseBranchName) {
  *
  * @param {Octokit} octokit
  * @param {string} releaseBranchName
- * @throws {Error} If there is no Build Release Artifacts workflow run on the
+ * @throws {Error} If the request fails.
+ * @throws {Error} If no Build Release Artifacts workflow is found on the
  * release branch.
  * @return {Promise<Object>} The build artifact workflow run.
  */
 async function getBuildArtifactsWorkflow(octokit, releaseBranchName) {
   // Fetch the Build Release Artifact workflow run on the release branch
-  try {
-    const res = await octokit.request(
-        "GET /repos/{owner}/{repo}/actions/runs", {
-          owner: OWNER,
-          repo: REPO,
-          branch: releaseBranchName,
-          headers: {
-            "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
-          },
-        });
+  const res = await octokit.request(
+      "GET /repos/{owner}/{repo}/actions/runs", {
+        owner: OWNER,
+        repo: REPO,
+        branch: releaseBranchName,
+        headers: {
+          "X-GitHub-Api-Version": X_GITHUB_API_VERSION,
+        },
+      });
 
-    for (const workflow of res.data.workflow_runs) {
-      if (workflow.name === "Build Release Artifacts") {
-        return workflow;
-      }
+  for (const workflow of res.data.workflow_runs) {
+    if (workflow.name === "Build Release Artifacts") {
+      return workflow;
     }
-
-    throw new Error(`No Build Release Artifacts workflow found on 
-    ${releaseBranchName}`);
-  } catch (err) {
-    error("error while fetching build artifact status", {error: err.message});
-    throw err;
   }
+
+  throw new Error(`No Build Release Artifacts workflow found on 
+    ${releaseBranchName}`);
 }
 
 /**
@@ -307,7 +286,7 @@ module.exports = {
   getReleaseConfig,
   getReleaseReport,
   getLibraryMetadata,
-  checkReleaseBranchExists,
+  getReleaseBranch,
   getBuildArtifactsWorkflow,
   verifySignature,
   REPO_URL,

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -19,14 +19,15 @@ const {
   getReleaseData,
   deleteAllReleaseData,
   releaseExists,
+  setReleaseError,
 } = require("../database/database.js");
 const {
-  checkReleaseBranchExists,
   getReleaseConfig,
   getReleaseReport,
   getBuildArtifactsWorkflow,
   listCheckRuns,
   getLibraryMetadata,
+  getReleaseBranch,
 } = require("../github/github.js");
 const {
   validateNewReleases,
@@ -38,6 +39,7 @@ const {
   calculateReleaseState,
   filterOutKtx,
   mergeKtxIntoRoot,
+  getStackTrace,
 } = require("../utils/utils.js");
 const {authenticateUser} = require("../utils/auth.js");
 const RELEASE_STATES = require("../utils/releaseStates.js");
@@ -435,11 +437,18 @@ async function modifyRelease(req, res) {
  * if the release is active. It also handles possible errors and updates
  * the release state to "error" if an exception is thrown.
  *
+ * We store the logs in Firestore so that we can view them provide
+ * context for any errors that occur in the dashboard. We only store errors
+ * here because this is the only place where a release may enter an error
+ * state.
+ *
  * @param {string} releaseId - The ID of the release to sync.
  * @param {Object} octokit - The Octokit instance for interacting with the
  * GitHub API.
- * @throws Will throw an error if the release branch does not exist or if
- * any of the promises reject.
+ * @throws {Error} If the release state cannot be determined from the
+ * state of the release. If a sync fails, the release state will be set to
+ * "error", and the release operator must resolve the issue and attempt
+ * to sync again.
  */
 async function syncReleaseState(releaseId, octokit) {
   // Get the release document from Firestore
@@ -463,21 +472,24 @@ async function syncReleaseState(releaseId, octokit) {
     return;
   }
 
-  const releaseBranchExists = await checkReleaseBranchExists(
-      octokit,
-      releaseData.releaseBranchName,
-  );
-
+  // If we can get the release branch, then we know that it exists.
+  // If the request fails, we know that the release branch does not exist.
   // If release release has passed the codeFreezeDate but the release
   // branch does not exist, we can't proceed with syncing the release.
   // The release branch should exist at this point, so we enter an
   // error state.
-  if (!releaseBranchExists) {
-    log("Release branch does not exist", {releaseData: releaseData});
-    await updateReleaseState(releaseId, RELEASE_STATES.ERROR);
-    throw new Error(
-        `Release branch ${releaseData.releaseBranchName} does not exist`,
+  try {
+    await getReleaseBranch(
+        octokit,
+        releaseData.releaseBranchName,
     );
+  } catch (err) {
+    await handleReleaseError(
+        releaseId,
+        err,
+        "Could not retrieve the release branch from GitHub.",
+    );
+    throw err;
   }
 
   // Since the release branch exists, we can fetch data from GitHub
@@ -559,9 +571,11 @@ async function syncReleaseState(releaseId, octokit) {
 
     await updateRelease(releaseId, updatedReleaseData);
   } catch (err) {
-    await updateReleaseState(releaseId, RELEASE_STATES.ERROR);
-    error("Failed to sync release for a release that has passed code freeze"
-        , {releaseId: releaseId, error: err.message});
+    await handleReleaseError(
+        releaseId,
+        err,
+        "Failed to sync release data from release branch on GitHub",
+    );
     throw err;
   }
 }
@@ -617,6 +631,34 @@ async function deleteRelease(req, res) {
     );
     return res.status(200).send("OK");
   });
+}
+
+/**
+ * Handles errors that occur while syncing a release.
+ *
+ * Logs the error, sets the release state to "error", and stores the error
+ * in Firestore. The error can then be viewed in the dashboard, along
+ * with the stack trace.
+ *
+ * @param {string} releaseId
+ * @param {Error} err - The error that occurred.
+ * @param {string} contextMsg - A message to provide context for the error.
+ */
+async function handleReleaseError(releaseId, err, contextMsg) {
+  error("Error while syncing release",
+      {releaseId: releaseId,
+        error: err.message,
+      },
+  );
+
+  const stackTrace = getStackTrace(err);
+  await setReleaseError(
+      releaseId,
+      err.message,
+      stackTrace,
+      contextMsg,
+  );
+  await updateReleaseState(releaseId, RELEASE_STATES.ERROR);
 }
 
 

--- a/functions/test/utils/utils.test.js
+++ b/functions/test/utils/utils.test.js
@@ -5,6 +5,7 @@ const {
   calculateReleaseState,
   processLibraryNames,
   parseCommitTitleFromMessage,
+  getStackTrace,
 } = require("../../utils/utils.js");
 const RELEASE_STATES = require("../../utils/releaseStates");
 const {expect} = require("chai");
@@ -223,5 +224,23 @@ describe("parseCommitTitleFromMessage", () => {
   it("should throw an error on empty strings", () => {
     const message = "";
     expect(() => parseCommitTitleFromMessage(message)).to.throw();
+  });
+});
+
+describe("getStackTrace", () => {
+  it("should throw an error if the argument is not an Error object", () => {
+    const notAnError = "Just a string";
+
+    expect(() => getStackTrace(notAnError))
+        .to.throw("Provided argument is not an Error object");
+  });
+
+  it("should return a formatted stack trace for a valid Error object", () => {
+    const error = new Error("Test error");
+
+    const result = getStackTrace(error);
+
+    expect(result).to.contain("Test error");
+    expect(result).to.contain("at");
   });
 });

--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -203,7 +203,9 @@ function filterOutKtx(libaries) {
  */
 function getStackTrace(error) {
   if (!(error instanceof Error)) {
-    throw new Error("Provided argument is not an Error object");
+    throw new Error(
+        `Provided argument is not an Error object: ${error}}`,
+    );
   }
 
   return error.stack.trim();

--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -194,6 +194,21 @@ function filterOutKtx(libaries) {
   return libaries.filter((library) => !library.includes("/ktx"));
 }
 
+/**
+ * Gets the stack trace from an error.
+ *
+ * @param {Error} error - The error to get the stack trace from.
+ * @throws {Error} If the provided argument is not an Error object.
+ * @return {string} The stack trace.
+ */
+function getStackTrace(error) {
+  if (!(error instanceof Error)) {
+    throw new Error("Provided argument is not an Error object");
+  }
+
+  return error.stack.trim();
+}
+
 module.exports = {
   convertDateToTimestamp,
   convertReleaseDatesToTimestamps,
@@ -204,4 +219,5 @@ module.exports = {
   mergeKtxIntoRoot,
   filterOutKtx,
   getCommitIdsFromChanges,
+  getStackTrace,
 };


### PR DESCRIPTION
When an error occurs when trying to sync a release with GitHub data, store the stack trace in Firestore. This will allow the dashboard to display stack traces to provide context for errors.

The collection that contains the stack traces should only be readable by administrators.