### PR TITLE
Track libraries that were opted out

### DIFF
--- a/functions/github/github.js
+++ b/functions/github/github.js
@@ -1,6 +1,7 @@
 const {log, error} = require("firebase-functions/logger");
 const {parseGradlePropertiesForVersion} = require("../utils/utils.js");
 const crypto = require("crypto");
+const {getUniqueValues} = require("../utils/utils.js");
 
 const OWNER = "firebase";
 const REPO = "firebase-android-sdk";
@@ -126,20 +127,26 @@ async function getReleaseReport(octokit, releaseData) {
 }
 
 /**
- * Fetches and returns metadata for each library in the release configuration.
- * The metadata includes the updated version, whether the library is opted in
- * to the release, and whether the library is lockstep. A library is lockstep
- * if it is part of the release but has no changes. A library is opted in if
- * it was not originally part of the release report, but has been manually opted
- * in by being added to the release configuration.
+ * Fetches and returns metadata for each library in the release according to
+ * the list of libraries in the release, and the changes that we know about.
+ * Metadata includes whether the library is part of a group release, whether
+ * the library is opted in to the release, and the updated version of the
+ * library.
  *
- * Fetches and returns metadata for each library in the release according
- * to the list of libraries in libraryNames. The metadata includes the updated
- * version, whether the library is opted in to the release, and whether the
- * library is a part of a group release. A library is a part of a group release
- * if it is part of the release but has no changes.
- * A library is opted in if it is not in the libraryChanges, but is in the
- * libraryNames.
+ * A library is part of a group release if it has zero changes, but is included
+ * in the release.
+ *
+ * A library is opted in to a release if it is not included in our changes at
+ * all, but was included in the release. Similarly, a library is opted out of
+ * a release if it is included in our changes, but it is not included in the
+ * list of releases.
+ *
+ * Note: These inferences for metadata are made with the assumption that
+ * the changes for a release are only generated once at the initial cut of
+ * the release, and that libraries that are part of a group release are
+ * included in those changes, but are just empty. We also assume that
+ * the list of changes is what represents the libraries that are truly
+ * releasing, whether they are included in the changes or not.
  *
  * @param {Octokit} octokit - The authenticated Octokit client.
  * @param {string} releaseBranchName - The release branch name
@@ -156,8 +163,9 @@ async function getLibraryMetadata(
     libraryChanges,
 ) {
   const libraryMetadata = {};
-  const allLibraryNames = [...libraryNames, ...Object.keys(libraryChanges)]
-      .filter((value, index, self) => self.indexOf(value) === index);
+  const allLibraryNames = getUniqueValues(
+      [...libraryNames, ...Object.keys(libraryChanges)],
+  );
   const libraryVersions = await getLibraryVersions(
       octokit,
       releaseBranchName,
@@ -167,13 +175,11 @@ async function getLibraryMetadata(
   for (const library in libraryVersions) {
     if (Object.prototype.hasOwnProperty.call(libraryVersions, library)) {
       const libraryIsReleasing = libraryNames.includes(library);
-      const libraryHasChanges = libraryChanges[library] &&
-        libraryChanges[library].length > 0;
       libraryMetadata[library] = {
         "updatedVersion": libraryVersions[library],
-        "optedIn": libraryIsReleasing && !libraryHasChanges,
-        "optedOut": !libraryIsReleasing && libraryHasChanges,
-        "libraryGroupRelease": !libraryChanges[library] ||
+        "optedIn": libraryIsReleasing && !libraryChanges[library],
+        "optedOut": !libraryIsReleasing && libraryChanges[library],
+        "libraryGroupRelease": libraryChanges[library] &&
         libraryChanges[library].length === 0,
       };
     }

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -518,6 +518,8 @@ async function syncReleaseState(releaseId, octokit) {
         libraryChanges,
     );
 
+    log("Fetched library metadata", {libraryMetadata: libraryMetadata});
+
     // Get the status of the check suite running on the release branch
     const checkRuns = await listCheckRuns(octokit,
         releaseData.releaseBranchName);

--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -194,6 +194,18 @@ function filterOutKtx(libaries) {
   return libaries.filter((library) => !library.includes("/ktx"));
 }
 
+/**
+ * Filters out duplicate values from an array.
+ *
+ * @param {Array} arr
+ * @return {Array} The updated array without any duplicate values.
+ */
+function getUniqueValues(arr) {
+  return arr.filter(
+      (value, index, self) => self.indexOf(value) === index,
+  );
+}
+
 module.exports = {
   convertDateToTimestamp,
   convertReleaseDatesToTimestamps,
@@ -204,4 +216,5 @@ module.exports = {
   mergeKtxIntoRoot,
   filterOutKtx,
   getCommitIdsFromChanges,
+  getUniqueValues,
 };


### PR DESCRIPTION
This resolves some of the issues with the m135 release, where computing metadata for transport-runtime would fail because we didn't handle the case where libraries had changes in the release report, but not in the release config.