### PR TITLE
Encoded libary doc IDs to not contain slashes

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -11,6 +11,7 @@ const {
 } = require("../utils/utils.js");
 const {REPO_URL} = require("../github/github.js");
 const {warn} = require("firebase-functions/logger");
+const REGEX = require("../utils/regex.js");
 
 /**
  * Check if a release document with a given releaseId exists in Firestore.
@@ -230,6 +231,20 @@ async function batchDeleteReleaseLibraries(batch, releaseId) {
 }
 
 /**
+ * Since Firestore documents can't have '/' in their IDs, we need to
+ * encode the library name and version into a unique ID that does
+ * not have that character.
+ *
+ * @param {string} libraryName
+ * @param {string} updatedVersion
+ * @return {string} The ID of the library document.
+ */
+function encodeLibraryDocId(libraryName, updatedVersion) {
+  const encodedLibraryName = libraryName.replace(REGEX.SLASH, ":");
+  return `${encodedLibraryName}-${updatedVersion}`;
+}
+
+/**
  * Adds new library release documents to Firestore batch.
  *
  * Note that this will not commit the change, it merely adds it to
@@ -244,7 +259,7 @@ async function batchDeleteReleaseLibraries(batch, releaseId) {
 function batchSetLibrariesForRelease(batch, libraries, releaseId) {
   Object.entries(libraries).forEach(
       ([libraryName, {updatedVersion, optedIn, libraryGroupRelease}]) => {
-        const uniqueId = `${libraryName}-${updatedVersion}`;
+        const uniqueId = encodeLibraryDocId(libraryName, updatedVersion);
         const docRef = db.collection("libraries").doc(uniqueId);
         batch.set(docRef, {
           libraryName,

--- a/functions/utils/regex.js
+++ b/functions/utils/regex.js
@@ -15,6 +15,8 @@ const REGEX = {
   // This regular expression matches a valid release name. Valid release names
   // are of the form "M<releaseNumber>".
   RELEASE_NAME: /^M\d+\S*$/,
+  // This regular expression matches slashes.
+  SLASH: /\//g,
 };
 
 module.exports = REGEX;


### PR DESCRIPTION
Encode library document IDs to replace `/` with `:`, since Firestore does not allow us to have document IDs with slashes.
This fixes an issue with the m135 release where `transport/transport-runtime` raised an error because we attempted to create a firestore document with an invalid character (https://github.com/firebase/firebase-android-sdk/blob/786a18d4be0530496941145a3c7d553b74cd7994/release_report.json#L137).