### PR TITLE
Remove release name restrictions

### DIFF
--- a/functions/test/validation/validation.test.js
+++ b/functions/test/validation/validation.test.js
@@ -4,45 +4,9 @@ const {
   validateNewReleases,
   validateNewReleasesStructure,
   isValidDate,
-  isValidReleaseName,
 } = require("../../validation/validation.js");
 const ERRORS = require("../../utils/errors.js");
 const {Timestamp} = require("firebase-admin/firestore");
-
-describe("isValidReleaseName", () => {
-  it("should return true for a valid release name", () => {
-    const validReleaseName = "M123";
-    expect(isValidReleaseName(validReleaseName)).to.be.true;
-  });
-
-  it("should return false for a release name without the M prefix", () => {
-    const invalidReleaseName = "123";
-    expect(isValidReleaseName(invalidReleaseName)).to.be.false;
-  });
-
-  it("should return true for a release name with non-numeric characters"+
-    " after the M", () => {
-    const invalidReleaseName = "M12_A12";
-    expect(isValidReleaseName(invalidReleaseName)).to.be.true;
-  });
-
-  it("should return false for a release name with non-numeric characters"+
-    " before the M", () => {
-    const invalidReleaseName = "AM12";
-    expect(isValidReleaseName(invalidReleaseName)).to.be.false;
-  });
-
-  it("should return false for a release name with non-numeric characters"+
-    " between the M and the relase number", () => {
-    const invalidReleaseName = "MA12";
-    expect(isValidReleaseName(invalidReleaseName)).to.be.false;
-  });
-
-  it("should return false for an empty string", () => {
-    const invalidReleaseName = "";
-    expect(isValidReleaseName(invalidReleaseName)).to.be.false;
-  });
-});
 
 describe("validateNewReleases", () => {
   it("should return no errors for valid releases when there are no previous"+
@@ -106,7 +70,7 @@ describe("validateNewReleases", () => {
     expect(errors).to.be.an("array").that.is.empty;
   });
 
-  it("should return an error for invalid release name", async () => {
+  it("should not return an error for invalid release name", async () => {
     const newReleases = [
       {
         releaseName: "101",
@@ -118,15 +82,11 @@ describe("validateNewReleases", () => {
     const existingReleases = [];
 
     const errors = await validateNewReleases(newReleases, existingReleases);
-    const expectedErrors = {
-      message: ERRORS.INVALID_RELEASE_NAME,
-      offendingRelease: newReleases[0],
-    };
 
-    expect(errors).to.deep.include(expectedErrors);
+    expect(errors).to.be.an("array").that.is.empty;
   });
 
-  it("should return an error for invalid release name", async () => {
+  it("should not return an error for invalid release name", async () => {
     const newReleases = [
       {
         releaseName: "m101",
@@ -138,12 +98,8 @@ describe("validateNewReleases", () => {
     const existingReleases = [];
 
     const errors = await validateNewReleases(newReleases, existingReleases);
-    const expectedErrors = {
-      message: ERRORS.INVALID_RELEASE_NAME,
-      offendingRelease: newReleases[0],
-    };
 
-    expect(errors).to.deep.include(expectedErrors);
+    expect(errors).to.be.an("array").that.is.empty;
   });
 
   it("should return an error for invalid date", async () => {

--- a/functions/validation/validation.js
+++ b/functions/validation/validation.js
@@ -1,17 +1,5 @@
 const {Timestamp} = require("firebase-admin/firestore");
 const ERRORS = require("../utils/errors.js");
-const REGEX = require("../utils/regex.js");
-
-/**
- * Helper function to check the release name format.
- * The format of release names must be "M<releaseNumber>"
- *
- * @param {string} name - The release name.
- * @return {bool} - True if the release name is valid.
- */
-function isValidReleaseName(name) {
-  return REGEX.RELEASE_NAME.test(name);
-}
 
 /** Helper function to check that a string represents a valid date.
  *
@@ -46,11 +34,6 @@ function validateReleaseName(release) {
       release.releaseName.trim() === "") {
     errors.push({
       message: ERRORS.INVALID_RELEASE_FIELD,
-      offendingRelease: release,
-    });
-  } else if (!isValidReleaseName(release.releaseName)) {
-    errors.push({
-      message: ERRORS.INVALID_RELEASE_NAME,
       offendingRelease: release,
     });
   }
@@ -237,7 +220,6 @@ function validateNewReleasesStructure(newReleases) {
 }
 
 module.exports = {
-  isValidReleaseName,
   isValidDate,
   validateRelease,
   validateNewReleases,


### PR DESCRIPTION
Removed restrictions on release names. It is up to the release operators to make sure that the release name is valid.

This makes the dashboard more flexible, in the case where naming conventions change (e.g. lowercase or upper case M) or if release operators want to have a release name that does not follow the convention (e.g. m100_test).

This is just an initial idea, I'm open to loosening the restriction rather than removing it entirely.