### PR TITLE
Release toggle button and API changes

### DIFF
--- a/firebase-android-release-dashboard/src/api/index.js
+++ b/firebase-android-release-dashboard/src/api/index.js
@@ -95,6 +95,7 @@ async function refreshRelease(releaseId) {
  * @param {string} releaseOperator - The new operator of the release.
  * @param {Date} codeFreezeDate - The new code freeze date of the release.
  * @param {Date} releaseDate - The new release date of the release.
+ * @param {boolean} isReleased - Whether the release is released.
  * @return {Promise<Object>} - Response object.
  */
 async function modifyRelease(
@@ -104,6 +105,7 @@ async function modifyRelease(
     releaseOperator,
     codeFreezeDate,
     releaseDate,
+    isReleased,
 ) {
   const token = await auth.currentUser.getIdToken();
   const response = await axios.post(MODIFY_RELEASE_URL, {
@@ -114,6 +116,7 @@ async function modifyRelease(
       releaseOperator: releaseOperator,
       codeFreezeDate: format(codeFreezeDate, API_DATE_FORMAT),
       releaseDate: format(releaseDate, API_DATE_FORMAT),
+      isReleased: isReleased,
     },
   },
   {

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRow/ReleaseRow.js
@@ -29,9 +29,11 @@ function ReleaseRow({releaseId, openSnackbar}) {
     deleting,
     refreshing,
     submitting,
+    toggling,
     handleDeleteClick,
     handleRefreshClick,
     handleSubmitClick,
+    handleReleasedToggle,
   } = useAdminReleaseActions(release, openSnackbar, setEditing);
 
   /**
@@ -93,9 +95,11 @@ function ReleaseRow({releaseId, openSnackbar}) {
           release={release}
           refreshing={refreshing}
           deleting={deleting}
+          toggling={toggling}
           handleRefreshClick={handleRefreshClick}
           handleEditClick={handleEditClick}
           handleDeleteClick={handleDeleteClick}
+          handleReleasedToggle={handleReleasedToggle}
         />
       </TableRow>
       <EditReleaseDialog

--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
@@ -5,6 +5,7 @@ import React from "react";
 import {RELEASE_STATES} from "../../../utils/releaseStates";
 import StateChip from "../../Release/StateChip/StateChip";
 import ReleaseActionButtons from "../ReleaseActionButtons/ReleaseActionButtons";
+import ToggleReleaseButton from "../ToggleReleaseButton/ToggleReleaseButton";
 
 /**
  * Displays the release's metadata in table cells.
@@ -18,10 +19,12 @@ import ReleaseActionButtons from "../ReleaseActionButtons/ReleaseActionButtons";
  * @param {string} release.state - Release state.
  * @param {boolean} refreshing - Whether the release is being refreshed.
  * @param {boolean} deleting - Whether the release is being deleted.
+ * @param {boolean} toggling - Whether the release state is being toggled.
  * @param {Function} handleRefreshClick - Function to handle refresh button
  * click.
  * @param {Function} handleEditClick - Function to handle edit button click.
  * @param {Function} handleDeleteClick - Function to handle delete button click.
+ * @param {Function} handleReleasedToggle - Function to handle released toggle
  * @return {JSX.Element} Rendered component.
  */
 function ReleaseRowContent(
@@ -29,9 +32,11 @@ function ReleaseRowContent(
       release,
       refreshing,
       deleting,
+      toggling,
       handleRefreshClick,
       handleEditClick,
       handleDeleteClick,
+      handleReleasedToggle,
     },
 ) {
   return (
@@ -59,6 +64,13 @@ function ReleaseRowContent(
       <TableCell>
         <StateChip state={release.state} />
       </TableCell>
+      <TableCell>
+        <ToggleReleaseButton
+          release={release}
+          toggling={toggling}
+          handleReleasedToggle={handleReleasedToggle}
+        />
+      </TableCell>
       <ReleaseActionButtons
         refreshing={refreshing}
         deleting={deleting}
@@ -81,9 +93,11 @@ ReleaseRowContent.propTypes = {
   }).isRequired,
   refreshing: PropTypes.bool.isRequired,
   deleting: PropTypes.bool.isRequired,
+  toggling: PropTypes.bool.isRequired,
   handleRefreshClick: PropTypes.func.isRequired,
   handleEditClick: PropTypes.func.isRequired,
   handleDeleteClick: PropTypes.func.isRequired,
+  handleReleasedToggle: PropTypes.func.isRequired,
 };
 
 export default ReleaseRowContent;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/ToggleReleaseButton.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/ToggleReleaseButton.js
@@ -1,0 +1,80 @@
+import {Button, CircularProgress, Typography} from "@material-ui/core";
+import {Check, History} from "@mui/icons-material";
+import PropTypes from "prop-types";
+import React from "react";
+import {RELEASE_STATES} from "../../../utils/releaseStates";
+import useStyles from "./styles";
+
+const toggleIsDisabled = {
+  [RELEASE_STATES.SCHEDULED]: true,
+  [RELEASE_STATES.CODE_FREEZE]: true,
+  [RELEASE_STATES.RELEASE_DAY]: false,
+  [RELEASE_STATES.RELEASED]: false,
+  [RELEASE_STATES.DELAYED]: false,
+  [RELEASE_STATES.ERROR]: true,
+};
+
+/**
+ * A button that toggles the release state between released and delayed.
+ *
+ * @param {Object} release - Release object
+ * @param {string} release.state - Release state.
+ * @param {boolean} toggling - Whether the release state is being toggled.
+ * @param {Function} handleReleasedToggle - Function to handle released toggle
+ * @return {JSX.Element} Rendered component.
+ */
+function ToggleReleaseButton({release, toggling, handleReleasedToggle}) {
+  const classes = useStyles();
+
+  let buttonText; let buttonIcon; let buttonClass;
+  switch (release.state) {
+    case RELEASE_STATES.RELEASED:
+      buttonText = "Mark as Delayed";
+      buttonIcon = <History />;
+      buttonClass = classes.unemphasizedButton;
+      break;
+    case RELEASE_STATES.DELAYED:
+    case RELEASE_STATES.RELEASE_DAY:
+      buttonText = "Mark as Released";
+      buttonIcon = <Check />;
+      buttonClass = classes.emphasizedButton;
+      break;
+    default:
+      buttonText = "";
+      buttonIcon = null;
+      buttonClass = classes.defaultButton;
+  }
+
+  return (
+    <Button
+      size={"small"}
+      variant={"contained"}
+      disabled={toggleIsDisabled[release.state]}
+      onClick={() => handleReleasedToggle(release)}
+      className={buttonClass}
+      startIcon={
+            toggling ?
+            <CircularProgress
+              size={20}
+              color="white"
+              className={classes.releaseButtonIcon}
+            /> :
+             buttonIcon
+      }
+    >
+      <Typography className={classes.releaseButtonText}>
+        {buttonText}
+      </Typography>
+    </Button>
+  );
+}
+
+ToggleReleaseButton.propTypes = {
+  release: PropTypes.shape({
+    state: PropTypes.string.isRequired,
+  }).isRequired,
+  toggling: PropTypes.bool.isRequired,
+  handleReleasedToggle: PropTypes.func.isRequired,
+};
+
+export default ToggleReleaseButton;

--- a/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/index.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ToggleReleaseButton";

--- a/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/styles.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ToggleReleaseButton/styles.js
@@ -1,0 +1,21 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  releaseButtonIcon: {
+    alignContent: "center",
+  },
+  releaseButtonText: {
+    textTransform: "none",
+    minWidth: "130px",
+  },
+  emphasizedButton: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+  },
+  unemphasizedButton: {
+    backgroundColor: theme.palette.primary.disabled,
+    color: theme.palette.primary.contrastText,
+  },
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/config/theme.js
+++ b/firebase-android-release-dashboard/src/config/theme.js
@@ -31,6 +31,7 @@ const theme = createTheme({
       light: firebaseColors.googleBlue2,
       dark: firebaseColors.firebaseNavy,
       contrastText: "#ffffff",
+      disabled: grey[500],
     },
     secondary: {
       main: firebaseColors.firebaseOrange,

--- a/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
+++ b/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
@@ -18,6 +18,7 @@ const useReleaseActions = (release, openSnackbar, setEditing) => {
   const [deleting, setDeleting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [toggling, setToggling] = useState(false);
 
   /**
    * Handle a click on the delete button by calling the deleteRelease API
@@ -73,6 +74,7 @@ const useReleaseActions = (release, openSnackbar, setEditing) => {
           "ACore team member", // TODO: Replace with actual operator
           editedRelease.codeFreezeDate,
           editedRelease.releaseDate,
+          editedRelease.isReleased,
       );
       if (response.status === 200) {
         openSnackbar("Release modified successfully", "success");
@@ -87,13 +89,42 @@ const useReleaseActions = (release, openSnackbar, setEditing) => {
     setSubmitting(false);
   };
 
+  /**
+   *
+   * @param {Object} release
+   */
+  const handleReleasedToggle = async (release) => {
+    setToggling(true);
+    try {
+      const response = await modifyRelease(
+          release.id,
+          release.releaseName,
+          release.releaseBranchName,
+          release.releaseOperator,
+          release.codeFreezeDate,
+          release.releaseDate,
+          !release.isReleased, // Toggle
+      );
+      if (response.status === 200) {
+        openSnackbar("Release state toggled sucessfully", "success");
+      } else {
+        openSnackbar("Failed to toggle release state", "error");
+      }
+    } catch (error) {
+      openSnackbar("Error occurred while toggling release state", "error");
+    }
+    setToggling(false);
+  };
+
   return {
     deleting,
     refreshing,
     submitting,
+    toggling,
     handleDeleteClick,
     handleRefreshClick,
     handleSubmitClick,
+    handleReleasedToggle,
   };
 };
 

--- a/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
+++ b/firebase-android-release-dashboard/src/hooks/useAdminReleaseActions.js
@@ -90,6 +90,8 @@ const useReleaseActions = (release, openSnackbar, setEditing) => {
   };
 
   /**
+   * Handle a click on the released toggle button by calling the modifyRelease
+   * API with the toggled release state.
    *
    * @param {Object} release
    */

--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -120,14 +120,14 @@ async function getReleaseData(releaseId) {
  */
 function releaseToFirestoreObject(release) {
   return {
-    state: RELEASE_STATES.SCHEDULED,
+    state: RELEASE_STATES.SCHEDULED, // Temporary state until release is synced
     releaseName: release.releaseName,
     releaseOperator: "ACore Team Member", // release.releaseOperator,
     codeFreezeDate: release.codeFreezeDate,
     releaseDate: release.releaseDate,
     releaseBranchName: release.releaseBranchName,
     releaseBranchLink: `${REPO_URL}/tree/${release.releaseBranchName}`,
-    isComplete: false,
+    isReleased: release.isReleased,
     buildArtifactStatus: "",
     buildArtifactConclusion: "",
     buildArtifactLink: "",

--- a/functions/handlers/handlers.js
+++ b/functions/handlers/handlers.js
@@ -450,7 +450,7 @@ async function syncReleaseState(releaseId, octokit) {
   const releaseState = calculateReleaseState(
       releaseData.codeFreezeDate.toDate(),
       releaseData.releaseDate.toDate(),
-      releaseData.isComplete);
+      releaseData.isReleased);
 
   log("Inferred release state", {releaseState: releaseState});
 
@@ -617,7 +617,6 @@ async function deleteRelease(req, res) {
     return res.status(200).send("OK");
   });
 }
-
 
 module.exports = {
   addReleases,

--- a/functions/test/utils/utils.test.js
+++ b/functions/test/utils/utils.test.js
@@ -137,7 +137,7 @@ describe("calculateReleaseState", () => {
         .to.equal(RELEASE_STATES.RELEASE_DAY);
   });
 
-  it("should return RELEASED if release date has passed and isComplete " +
+  it("should return RELEASED if release date has passed and isReleased " +
       "is true", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000);
@@ -146,7 +146,7 @@ describe("calculateReleaseState", () => {
         .to.equal(RELEASE_STATES.RELEASED);
   });
 
-  it("should return DELAYED if release date has passed and isComplete " +
+  it("should return DELAYED if release date has passed and isReleased " +
       "is false", () => {
     const now = new Date();
     const codeFreeze = new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000);

--- a/functions/test/validation/validation.test.js
+++ b/functions/test/validation/validation.test.js
@@ -54,13 +54,15 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "releases/${releaseName}",
+        isReleased: false,
       },
       {
-        releaseName: "m104",
+        releaseName: "M104",
         releaseOperator: "operator1",
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-08-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
       {
         releaseName: "M105",
@@ -68,10 +70,13 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-08-30",
         releaseDate: "2123-09-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
+
     const errors = await validateNewReleases(newReleases, existingReleases);
+
     expect(errors).to.be.an("array").that.is.empty;
   });
 
@@ -84,6 +89,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
       {
         releaseName: "M104",
@@ -91,6 +97,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-08-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
       {
         releaseName: "M105",
@@ -98,6 +105,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-08-30",
         releaseDate: "2123-09-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [
@@ -107,9 +115,12 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2022-06-30",
         releaseDate: "2022-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
+
     const errors = await validateNewReleases(newReleases, existingReleases);
+
     expect(errors).to.be.an("array").that.is.empty;
   });
 
@@ -121,6 +132,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
@@ -142,6 +154,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
@@ -163,6 +176,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "not a date",
         releaseDate: "not a date",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
@@ -185,6 +199,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-07-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
@@ -207,6 +222,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-07-07",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const existingReleases = [];
@@ -228,6 +244,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
       {
         releaseName: "M103",
@@ -235,6 +252,7 @@ describe("validateNewReleases", () => {
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
         releaseBranchName: "branch",
+        isReleased: false,
       },
     ];
     const errors = validateNewReleases(newReleases);
@@ -251,11 +269,55 @@ describe("validateNewReleases", () => {
         releaseOperator: "operator1",
         codeFreezeDate: "2123-06-30",
         releaseDate: "2123-07-07",
+        isReleased: false,
       },
     ];
+
     const errors = validateNewReleases(newReleases);
     const expectedErrors = {
       message: ERRORS.MISSING_RELEASE_FIELD,
+      offendingRelease: newReleases[0],
+    };
+
+    expect(errors).to.deep.include(expectedErrors);
+  });
+
+  it("should return an error for not having released state", async () => {
+    const newReleases = [
+      {
+        releaseName: "M101",
+        releaseOperator: "operator1",
+        codeFreezeDate: "2123-07-07",
+        releaseDate: "2123-07-07",
+      },
+    ];
+    const existingReleases = [];
+
+    const errors = await validateNewReleases(newReleases, existingReleases);
+    const expectedErrors = {
+      message: ERRORS.MISSING_RELEASE_FIELD,
+      offendingRelease: newReleases[0],
+    };
+
+    expect(errors).to.deep.include(expectedErrors);
+  });
+
+  it("should return an error for not having invalid"+
+  "released state", async () => {
+    const newReleases = [
+      {
+        releaseName: "M101",
+        releaseOperator: "operator1",
+        codeFreezeDate: "2123-07-07",
+        releaseDate: "2123-07-07",
+        isReleased: "not a boolean",
+      },
+    ];
+    const existingReleases = [];
+
+    const errors = await validateNewReleases(newReleases, existingReleases);
+    const expectedErrors = {
+      message: ERRORS.INVALID_RELEASE_FIELD,
       offendingRelease: newReleases[0],
     };
 
@@ -335,6 +397,20 @@ describe("validateNewReleasesStructure", () => {
           " property 'releaseDate'");
   });
 
+  it("should throw an error if a release property is of incorrect type", () => {
+    const newReleases = [{
+      releaseName: "M100",
+      releaseOperator: "operator1",
+      codeFreezeDate: Timestamp.now(),
+      releaseDate: Timestamp.now(),
+      releaseBranchName: "test",
+      isReleased: "not a boolean",
+    }];
+    expect(() => validateNewReleasesStructure(newReleases)).
+        to.throw("Each release should have a boolean"+
+        " property 'isReleased'");
+  });
+
   it("should not throw an error if all releases are correct", () => {
     const newReleases = [{
       releaseName: "M100",
@@ -342,6 +418,7 @@ describe("validateNewReleasesStructure", () => {
       codeFreezeDate: Timestamp.now(),
       releaseDate: Timestamp.now(),
       releaseBranchName: "branch",
+      isReleased: false,
     }];
     expect(() => validateNewReleasesStructure(newReleases)).to.not.throw();
   });

--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -61,13 +61,13 @@ function convertReleaseDatesToTimestamps(releases) {
  * @param {Date} codeFreeze The date on which the code for the release was
  * frozen.
  * @param {Date} release The scheduled release date.
- * @param {boolean} isComplete Indicates whether the release process has been
- * completed.
+ * @param {boolean} isReleased Flag that indicates whether the release has
+ * been released. This is set manually by administrators.
  * @return {string} The calculated state of the release.
  * @throws {Error} If the release state cannot be determined from the
  * provided parameters.
  */
-function calculateReleaseState(codeFreeze, release, isComplete) {
+function calculateReleaseState(codeFreeze, release, isReleased) {
   const now = new Date();
 
   // Get time difference in milliseconds
@@ -85,7 +85,7 @@ function calculateReleaseState(codeFreeze, release, isComplete) {
   } else if (diffDaysCodeFreeze < 0 && diffDaysRelease === 0) {
     return RELEASE_STATES.RELEASE_DAY;
   } else if (diffDaysRelease < 0) {
-    return isComplete ? RELEASE_STATES.RELEASED : RELEASE_STATES.DELAYED;
+    return isReleased ? RELEASE_STATES.RELEASED : RELEASE_STATES.DELAYED;
   } else {
     throw new Error(`Unable to calculate release state between 
     ${codeFreeze} and ${release} dates`);

--- a/functions/validation/validation.js
+++ b/functions/validation/validation.js
@@ -117,7 +117,7 @@ function validateReleaseDates(release) {
 }
 
 /**
- * Validates that the release isReleased status exists and is a boolean.
+ * Validates that the `release.isReleased` status exists and is a boolean.
  *
  * @param {Object} release - The release to validate.
  * @return {Array} errors - A list of errors from the validation of the released

--- a/functions/validation/validation.js
+++ b/functions/validation/validation.js
@@ -117,6 +117,31 @@ function validateReleaseDates(release) {
 }
 
 /**
+ * Validates that the release isReleased status exists and is a boolean.
+ *
+ * @param {Object} release - The release to validate.
+ * @return {Array} errors - A list of errors from the validation of the released
+ * status.
+ */
+function validateIsReleased(release) {
+  const errors = [];
+
+  if (release.isReleased === undefined) {
+    errors.push({
+      message: ERRORS.MISSING_RELEASE_FIELD,
+      offendingRelease: release,
+    });
+  } else if (typeof release.isReleased !== "boolean") {
+    errors.push({
+      message: ERRORS.INVALID_RELEASE_FIELD,
+      offendingRelease: release,
+    });
+  }
+
+  return errors;
+}
+
+/**
  * Check if all release names are unique. Note that this is not responsible for
  * checking if these releases already exist in the database, only for checking
  * that the release names are unique within the set of releases to be scheduled.
@@ -177,12 +202,14 @@ function validateRelease(release) {
   const operatorErrors = validateReleaseOperator(release);
   const dateErrors = validateReleaseDates(release);
   const branchErrors = validateReleaseBranch(release);
+  const releasedErrors = validateIsReleased(release);
 
   return [
     ...releaseNameErrors,
     ...operatorErrors,
     ...dateErrors,
     ...branchErrors,
+    ...releasedErrors,
   ];
 }
 
@@ -256,6 +283,12 @@ function validateNewReleaseStructure(release) {
   !(release.releaseBranchName !== "string")) {
     throw new Error("Each release should have a string property"+
     " property 'releaseBranchName'");
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(release, "isReleased") ||
+  typeof release.isReleased !== "boolean") {
+    throw new Error("Each release should have a boolean"+
+    " property 'isReleased'");
   }
 }
 


### PR DESCRIPTION
Button in release row of admin page that allows administrators to toggle the state of a release.
Transitions are:
`release day` -> `released`
`released` -> `delayed`
`delayed` -> `released`
![1](https://github.com/firebase/firebase-release-dashboard/assets/64338275/e93ec6e8-0d75-48e3-bbe0-9dbc505a4ac2)
![2](https://github.com/firebase/firebase-release-dashboard/assets/64338275/71301536-1f4b-48fb-a555-f7cb9ce6561d)


Note: The transition to `delayed` does not automatically happen if the release is not after the release day. So, if a release does not go out on the release day, the dashboard will just stay on `release day` until it's manually updated.  I'm thinking of setting up a Cloud Scheduler function to automatically transition from `code freeze` -> `release day`, and `release day` -> `delayed`, so that release operators don't have to manually re-sync or flip bits in the dashboard every time, since they might forget.