### PR TITLE
Set Firestore dates to be at 8AM UTC

### DIFF
--- a/functions/utils/utils.js
+++ b/functions/utils/utils.js
@@ -13,6 +13,7 @@ function convertDateToTimestamp(dateString) {
   try {
     // Attempt to parse the date string and convert to Firestore Timestamp
     const dateObject = new Date(dateString);
+    dateObject.setHours(8, 0, 0, 0); // Set to 8am UTC
     if (!isNaN(dateObject)) {
       return Timestamp.fromDate(dateObject);
     } else {


### PR DESCRIPTION
Timestamps were being set to the dates at 12AM UTC. When these dates would be pulled on the frontend, they'd be converted to the local timezone. So, in the case where the local timezone is behind UTC, the day would no longer be accurate (e.g. August 10, 12AM UTC, is August 9, 8PM UTC-4).

I think that ideally, we don't store the time of day for the release and code freeze dates. Unfortunately, doing this would require quite a few changes to be made (not using timestamps, JS Date objects anywhere- modifying the entire API and frontend), so this can be a temporary fix, and should not cause issues for any timezones.

Is there a better solution I'm not thinking about?
