### PR TITLE
Make release errors only readable by auth users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,18 +3,31 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
-    match /{document=**} {
+    match /releases/{document=**} {
       allow read: if true;
       allow write: if request.auth != null;
     }
+    
+    match /libraries/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+    
+    match /changes/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+    
+    match /checks/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+    
+    // Errors are only readable by authenticated users, and not writeable.
+    match /releaseError/{document=**} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
   }
 }
+


### PR DESCRIPTION
Release errors should only be readable by users who are signed in (ACore team members).