### PR TITLE
Fix release dates in release list header

### DIFF
--- a/firebase-android-release-dashboard/src/components/ReleaseList/ReleaseList.js
+++ b/firebase-android-release-dashboard/src/components/ReleaseList/ReleaseList.js
@@ -12,8 +12,8 @@ const STATE_HEADER = "State";
 
 const releaseListHeaderItems = [
   RELEASE_NAME_HEADER,
-  RELEASE_DATE_HEADER,
   CODE_FREEZE_DATE_HEADER,
+  RELEASE_DATE_HEADER,
   STATE_HEADER,
 ];
 


### PR DESCRIPTION
Reordered the code freeze and release date headers in the release list.

![header](https://github.com/firebase/firebase-release-dashboard/assets/64338275/b07c796e-4fd6-46d9-b03d-279cac5501cd)
