### PR TITLE
Make changes in different libraries unique

### DIFF
--- a/functions/database/database.js
+++ b/functions/database/database.js
@@ -239,6 +239,18 @@ function encodeLibraryDocId(libraryName, updatedVersion) {
 }
 
 /**
+ * Encode a change document ID.
+ *
+ * @param {string} commitId The id of the commit that the change is
+ * associated with.
+ * @param {string} libraryId The ID of the associated library.
+ * @return {string} The ID of the change document.
+ */
+function encodeChangeDocId(commitId, libraryId) {
+  return `${libraryId}-${commitId}`;
+}
+
+/**
  * Adds new library release documents to Firestore batch.
  *
  * Note that this will not commit the change, it merely adds it to
@@ -345,7 +357,8 @@ async function batchDeleteReleaseChanges(batch, releaseId) {
  */
 function batchSetReleaseChanges(batch, changes, libraryId, releaseId) {
   changes.forEach((change) => {
-    const docRef = db.collection("changes").doc(change.commitId);
+    const docId = encodeChangeDocId(change.commitId, libraryId);
+    const docRef = db.collection("changes").doc(docId);
     batch.set(docRef, {
       commitTitle: parseCommitTitleFromMessage(change.message),
       message: change.message,


### PR DESCRIPTION
Closes #50 

Old m135 release, where `Add third party license to aars` is only under `firebase-ml-modeldownloader`:
![image](https://github.com/firebase/firebase-release-dashboard/assets/64338275/a470f6a4-d9b2-42da-837d-a5d7dbb205f3)

m135 release after this change, where `Add third party license to aars` is now under all libraries where the commit was applied (appdistribution, and mlmodeldownloader):
![new](https://github.com/firebase/firebase-release-dashboard/assets/64338275/6695a251-1f91-41ed-a189-24b4e957bfdd)
