### PR TITLE
Display stack trace errors in dialog

### DIFF
--- a/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
+++ b/firebase-android-release-dashboard/src/components/AdminPage/ReleaseRowContent/ReleaseRowContent.js
@@ -62,7 +62,11 @@ function ReleaseRowContent(
         </Typography>
       </TableCell>
       <TableCell>
-        <StateChip state={release.state} />
+        <StateChip
+          state={release.state}
+          releaseId={release.id}
+          isLoggedIn={true}
+        />
       </TableCell>
       <TableCell>
         <ToggleReleaseButton

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/ReleaseErrorDialog.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/ReleaseErrorDialog.js
@@ -1,0 +1,47 @@
+import {
+  Button,
+  Dialog, DialogActions, DialogContent,
+  DialogContentText, DialogTitle,
+} from "@material-ui/core";
+import PropTypes from "prop-types";
+import React from "react";
+import useStyles from "./styles";
+
+/**
+ * A dialog to display the error details of a release.
+ *
+ * @param {Object} open - Whether the dialog is open.
+ * @param {Object} onClose - Function to handle close.
+ * @param {Object} releaseError - The error object.
+ * @return {JSX.Element} Rendered component.
+ */
+function ReleaseErrorDialog({open, onClose, releaseError}) {
+  const classes = useStyles();
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Error Details</DialogTitle>
+      <DialogContent>
+        <DialogContentText className={classes.stackTrace}>
+          {
+              releaseError ?
+              releaseError.stackTrace :
+              "No stack trace available. Check the Functions logs."
+          }
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+            Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+ReleaseErrorDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  releaseError: PropTypes.object,
+};
+
+export default ReleaseErrorDialog;

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/index.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ReleaseErrorDialog";

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/styles.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseErrorDialog/styles.js
@@ -1,0 +1,12 @@
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  stackTrace: {
+    fontFamily: "monospace",
+    fontSize: "0.8rem",
+    color: theme.palette.errorText,
+    whiteSpace: "pre-wrap",
+  },
+}));
+
+export default useStyles;

--- a/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/ReleaseMetadata.js
+++ b/firebase-android-release-dashboard/src/components/Release/ReleaseMetadata/ReleaseMetadata.js
@@ -5,6 +5,7 @@ import {format} from "date-fns";
 import {RELEASE_STATES} from "../../../utils/releaseStates";
 import useStyles from "./styles";
 import StateChip from "../StateChip/StateChip";
+import {useAuthentication} from "../../../hooks/useAuthentication";
 
 /**
  * Represents the metadata of a single release.
@@ -19,8 +20,10 @@ import StateChip from "../StateChip/StateChip";
  */
 function ReleaseMetadata({release}) {
   const classes = useStyles();
+  const {isLoggedIn} = useAuthentication();
 
   const {
+    id,
     releaseName,
     releaseDate,
     codeFreezeDate,
@@ -57,7 +60,11 @@ function ReleaseMetadata({release}) {
         </Typography>
       </Grid>
       <Grid item xs={3}>
-        <StateChip state={state} />
+        <StateChip
+          state={state}
+          releaseId={id}
+          isLoggedIn={isLoggedIn}
+        />
       </Grid>
     </Grid>
   );
@@ -65,6 +72,7 @@ function ReleaseMetadata({release}) {
 
 ReleaseMetadata.propTypes = {
   release: PropTypes.shape({
+    id: PropTypes.string.isRequired,
     releaseName: PropTypes.string.isRequired,
     releaseDate: PropTypes.instanceOf(Date).isRequired,
     codeFreezeDate: PropTypes.instanceOf(Date).isRequired,

--- a/firebase-android-release-dashboard/src/components/Release/StateChip/StateChip.js
+++ b/firebase-android-release-dashboard/src/components/Release/StateChip/StateChip.js
@@ -1,9 +1,11 @@
-import React from "react";
-import PropTypes from "prop-types";
 import {Chip} from "@material-ui/core";
-import {RELEASE_STATES} from "../../../utils/releaseStates";
-import useStyles from "./styles";
+import PropTypes from "prop-types";
+import React, {useState} from "react";
 import theme from "../../../config/theme";
+import useRecentReleaseError from "../../../hooks/useReleaseError";
+import {RELEASE_STATES} from "../../../utils/releaseStates";
+import ReleaseErrorDialog from "../ReleaseErrorDialog/ReleaseErrorDialog";
+import useStyles from "./styles";
 
 const chipColor = (state) => {
   const color = theme.palette.primary.contrastText;
@@ -23,24 +25,54 @@ const chipColor = (state) => {
 /**
  * Returns a chip containing the state of the release.
  *
+ * If the release is in the ERROR state, the chip is clickable and opens a
+ * dialog containing the error message.
+ *
  * @param {string} state - The state of the release.
+ * @param {string} releaseId - The ID of the release.
+ * @param {boolean} isLoggedIn - Whether the user is logged in.
  * @return {JSX.Element} The StateChip component.
  */
-function StateChip({state}) {
+function StateChip({state, releaseId, isLoggedIn}) {
   const styles = chipColor(state);
   const classes = useStyles(styles);
+  const [openDialog, setOpenDialog] = useState(false);
+  const releaseError = useRecentReleaseError(releaseId, isLoggedIn);
+
+  const handleClickOpen = () => {
+    setOpenDialog(true);
+  };
+
+  const handleClose = () => {
+    setOpenDialog(false);
+  };
+
+  const isClickable = isLoggedIn && state === RELEASE_STATES.ERROR;
 
   return (
-    <Chip
-      label={state}
-      className={classes.stateChip}
-      styles={chipColor(state)}
-    />
+    <>
+      <Chip
+        label={state}
+        className={classes.stateChip}
+        style={{
+          ...chipColor(state),
+          cursor: isClickable ? "pointer" : "default",
+        }}
+        onClick={isClickable ? handleClickOpen : null}
+      />
+      <ReleaseErrorDialog
+        open={openDialog}
+        onClose={handleClose}
+        releaseError={releaseError}
+      />
+    </>
   );
 }
 
 StateChip.propTypes = {
   state: PropTypes.oneOf(Object.values(RELEASE_STATES)).isRequired,
+  releaseId: PropTypes.string.isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
 };
 
 export default StateChip;

--- a/firebase-android-release-dashboard/src/config/theme.js
+++ b/firebase-android-release-dashboard/src/config/theme.js
@@ -54,6 +54,7 @@ const theme = createTheme({
       orange: orange[400],
       gray: grey[400],
     },
+    errorText: red[400],
   },
 });
 

--- a/firebase-android-release-dashboard/src/hooks/useReleaseError.js
+++ b/firebase-android-release-dashboard/src/hooks/useReleaseError.js
@@ -1,0 +1,60 @@
+import {
+  collection, limit, onSnapshot,
+  orderBy, query, where,
+} from "firebase/firestore";
+import {useEffect, useState} from "react";
+import {db} from "../firebase";
+
+/**
+ * Custom React hook to manage the state and side effects for fetching the
+ * most recent release error.
+ *
+ * We accept the isLoggedIn parameter to prevent the hook from fetching
+ * release errors when the user is not logged in. Conveniently, this also
+ * triggers the hook to fetch the release error when the user logs in.
+ *
+ * @param {string} id - The ID of the release to fetch errors for.
+ * @param {boolean} isLoggedIn - Whether the user is logged in.
+ * @return {Object} The most recent release error state.
+ */
+function useRecentReleaseError(id, isLoggedIn) {
+  const [releaseError, setReleaseError] = useState(null);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      // Get the most recent release error for the release
+      const q = query(
+          collection(db, "releaseError"),
+          where("releaseID", "==", id),
+          orderBy("timestamp", "asc"),
+          limit(1),
+      );
+
+      const unsubscribe = onSnapshot(q, (snapshot) => {
+        const docs = snapshot.docs;
+        if (docs.length) {
+          const doc = docs[0];
+          const data = doc.data();
+          setReleaseError({
+            id: doc.id,
+            ...data,
+            // Convert Firestore Timestamp to JS Date object
+            timestamp: data.timestamp.toDate(),
+          });
+        } else {
+          setReleaseError(null);
+        }
+      });
+
+      // Clean up the onSnapshot listener when the component is unmounted
+      return () => unsubscribe();
+    } else {
+      // If user is not logged in, we set releaseError to null
+      setReleaseError(null);
+    }
+  }, [id, isLoggedIn]);
+
+  return releaseError;
+}
+
+export default useRecentReleaseError;


### PR DESCRIPTION
Closes #42 

Signed in users can now click the error chip on releases (in the main and the admin page) to open a dialog containing the most recent stack trace error.

Users that are not signed in can't click the state chip at all. 

![err](https://github.com/firebase/firebase-release-dashboard/assets/64338275/721bae88-230b-48ab-84fc-92020467fa64)
